### PR TITLE
feat(134): make etag not required

### DIFF
--- a/aep/general/0134/aep.md.j2
+++ b/aep/general/0134/aep.md.j2
@@ -310,17 +310,19 @@ message Book {
 }
 ```
 
+- The `update_mask` field in the request does not affect the behavior of the
+  `etag` field, as it is not a field _being_ updated.
+
 {% tab oas %}
 
 **Note:** OAS example not yet written.
 
 {% endtabs %}
 
-The `etag` field **may** be either [required][] or [optional][]. If it is set,
-then the request **must** succeed if and only if the provided etag matches the
-server-computed value, and **must** fail with an `ABORTED` error otherwise. The
-`update_mask` field in the request does not affect the behavior of the `etag`
-field, as it is not a field _being_ updated.
+- The `etag` field **must** be [optional][].
+- If `etag` is set, then the request **must** succeed if and only if the
+provided etag matches the server-computed value, and **must** fail with an
+`ABORTED` / `409 Conflict` error otherwise.
 
 ### Expensive fields
 


### PR DESCRIPTION
making etag a require field will force the user
to perform a Get of the resource first to retrieve the etag - this can cause friction for simple clients like command-line interfaces or curl-ing a resource, and  makes the behavior of the standard method inconsistent across resources.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
