### PR TITLE
feat(136): improve wording around declarative clients

### DIFF
--- a/aep/general/0136/aep.md.j2
+++ b/aep/general/0136/aep.md.j2
@@ -119,16 +119,15 @@ permanent effect on data within the API.
   collection). For example, `:translateText` is preferable to `text:translate`.
 - Stateless methods **must** use `POST` if they involve billing.
 
-### Declarative-friendly resources
+### Usage in declarative clients
 
-Declarative-friendly resources usually **should not** employ custom methods
-(except specific declarative-friendly custom methods discussed in other AEPs),
-because declarative-friendly tools are unable to automatically determine what
-to do with them.
+APIs **should not** employ custom methods for functionality that is intended to
+be used in a [declarative client](/3#declarative-clients). Declarative clients
+use create,read,update,and delete operations to apply desired state, and
+integration of custom methods is manual and results in client-side complexity
+around state management to determine when the custom method should be invoked.
 
-An exception to this is for rarely-used, fundamentally imperative operations,
-such as a `Move`, `Rename`, or `Restart` operation, for which there would not
-be an expectation of declarative support.
+AEP's supported declarative clients cannot support custom methods.
 
 <!-- prettier-ignore-start -->
 [rfc 5789]: https://datatracker.ietf.org/doc/html/rfc5789


### PR DESCRIPTION
The existing guidance was a big vague on the impact of a custom method in a declarative client. This 
attempts to clarify the impact of making that choice.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x]  Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
