### PR TITLE
feat(8): adding style guide on error codes

### DIFF
--- a/aep/general/0008/aep.md.j2
+++ b/aep/general/0008/aep.md.j2
@@ -231,6 +231,10 @@ subdirectory); this ensures that the link works both on the AEP site, when
 viewing the Markdown file on GitHub, using the local development server, or a
 branch.
 
+### Error codes
+
+When referencing a error code, the prose **should** use the format `{google.api.error_code} / {http_status_code}`. For example, `OK / 200`.
+
 ## Rationale
 
 ### Designing for a broad set of clients


### PR DESCRIPTION
Since error codes can be succinct when describing gRPC and HTTP+JSON, we can just name them both in the AEPs.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

💝 Thank you!
