### PR TITLE
fix(openapi): publishes oas that passes linter

### DIFF
--- a/aep/general/0135/aep.md.j2
+++ b/aep/general/0135/aep.md.j2
@@ -96,7 +96,7 @@ Delete methods implement a common request pattern:
 
 {% tab oas %}
 
-{% sample '../example.oas.yaml', '$.paths./publishers/{publisher}/books/{book}.delete.responses.200' %}
+{% sample '../example.oas.yaml', '$.paths./publishers/{publisher}/books/{book}.delete.responses.204' %}
 
 - Delete methods **should** return `204 No Content` with no response body.
 

--- a/aep/general/0136/aep.md.j2
+++ b/aep/general/0136/aep.md.j2
@@ -26,14 +26,15 @@ apply consistently:
 - The HTTP URI **must** use a `:` character followed by the custom verb
   (`:archive` in the above example), and the verb in the URI **must** match the
   verb in the name of the RPC.
-  - If word separation is required, `camelCase` **must** be used.
+  - If word separation is required, `kebab-case` **must** be used.
+- The name of the RPC **should** be a verb followed by a noun.
+  - The name of the RPC **must not** contain prepositions ("for", "with",
+    etc.).
 
 {% tab proto %}
 
 {% sample 'library.proto', 'rpc ArchiveBook' %}
 
-- The name of the RPC **should** be a verb followed by a noun.
-  - The name **must not** contain prepositions ("for", "with", etc.).
 - The `body` clause in the `google.api.http` annotation **should** be `"*"`.
   - However, if using `GET` or `DELETE`, the `body` clause **must** be absent.
 - Custom methods **must** take a request message exactly matching the RPC name,
@@ -45,11 +46,11 @@ apply consistently:
 
 {% tab oas %}
 
-{% sample 'library.oas.yaml', '$.paths./publishers/{publisherId}/books/{bookId}:archive' %}
-
-- The name of the RPC **should** be a verb followed by a noun.
-  - The name of the RPC **must not** contain prepositions ("for", "with",
-    etc.).
+```http
+POST /v1/publishers/{publisher}/book/{book}:archive HTTP/2
+Host: bookstore.example.com
+Accept: application/json
+```
 
 {% endtabs %}
 
@@ -64,14 +65,14 @@ such:
 
 {% tab proto %}
 
-{% sample 'library.proto', 'rpc ArchiveBook' %}
+{% sample '../example.proto', 'rpc ArchivePublisher' %}
 
 - The parameter for the resource's path **must** be called `path`, and **must**
   be the only variable in the URI path.
 
 {% tab oas %}
 
-**Note:** OAS example not yet written.
+{% sample '../example.oas.yaml', '$.paths./publishers/{publisher}/books/{book}:archive' %}
 
 {% endtabs %}
 

--- a/aep/general/example.oas.yaml
+++ b/aep/general/example.oas.yaml
@@ -11,12 +11,56 @@
     {
       '/isbns':
         {
+          'get':
+            {
+              'description': 'List method for isbn',
+              'operationId': 'ListIsbn',
+              'parameters':
+                [
+                  {
+                    'name': 'max_page_size',
+                    'in': 'query',
+                    'schema': { 'type': 'integer' },
+                  },
+                  {
+                    'name': 'page_token',
+                    'in': 'query',
+                    'schema': { 'type': 'string' },
+                  },
+                ],
+              'responses':
+                {
+                  '200':
+                    {
+                      'description': 'Successful response',
+                      'content':
+                        {
+                          'application/json':
+                            {
+                              'schema':
+                                {
+                                  'type': 'object',
+                                  'properties':
+                                    {
+                                      'results':
+                                        {
+                                          'type': 'array',
+                                          'items':
+                                            {
+                                              '$ref': '#/components/schemas/isbn',
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
           'post':
             {
-              'summary': '',
               'description': 'Create method for isbn',
               'operationId': 'CreateIsbn',
-              'parameters': [],
               'responses':
                 {
                   '200':
@@ -34,7 +78,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -44,11 +87,42 @@
                 },
             },
         },
+      '/isbns/{isbn}':
+        {
+          'get':
+            {
+              'description': 'Get method for isbn',
+              'operationId': 'GetIsbn',
+              'parameters':
+                [
+                  {
+                    'name': 'isbn',
+                    'in': 'path',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
+              'responses':
+                {
+                  '200':
+                    {
+                      'description': 'Successful response',
+                      'content':
+                        {
+                          'application/json':
+                            {
+                              'schema':
+                                { '$ref': '#/components/schemas/isbn' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
       '/publishers':
         {
           'get':
             {
-              'summary': '',
               'description': 'List method for publisher',
               'operationId': 'ListPublisher',
               'parameters':
@@ -56,15 +130,11 @@
                   {
                     'name': 'max_page_size',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'integer' },
                   },
                   {
                     'name': 'page_token',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'string' },
                   },
                 ],
@@ -99,10 +169,8 @@
             },
           'post':
             {
-              'summary': '',
               'description': 'Create method for publisher',
               'operationId': 'CreatePublisher',
-              'parameters': [],
               'responses':
                 {
                   '200':
@@ -120,7 +188,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -137,7 +204,6 @@
         {
           'get':
             {
-              'summary': '',
               'description': 'Get method for publisher',
               'operationId': 'GetPublisher',
               'parameters':
@@ -145,7 +211,6 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -168,7 +233,6 @@
             },
           'patch':
             {
-              'summary': '',
               'description': 'Update method for publisher',
               'operationId': 'UpdatePublisher',
               'parameters':
@@ -176,7 +240,6 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -198,7 +261,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -212,7 +274,6 @@
             },
           'put':
             {
-              'summary': '',
               'description': 'Apply method for publisher',
               'operationId': 'ApplyPublisher',
               'parameters':
@@ -220,7 +281,6 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -242,7 +302,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -256,7 +315,6 @@
             },
           'delete':
             {
-              'summary': '',
               'description': 'Delete method for publisher',
               'operationId': 'DeletePublisher',
               'parameters':
@@ -264,15 +322,12 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'force',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'boolean' },
                   },
                 ],
@@ -290,7 +345,6 @@
         {
           'get':
             {
-              'summary': '',
               'description': 'List method for book',
               'operationId': 'ListBook',
               'parameters':
@@ -298,22 +352,17 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'max_page_size',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'integer' },
                   },
                   {
                     'name': 'page_token',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'string' },
                   },
                 ],
@@ -353,7 +402,6 @@
             },
           'post':
             {
-              'summary': '',
               'description': 'Create method for book',
               'operationId': 'CreateBook',
               'parameters':
@@ -361,7 +409,6 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -383,7 +430,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -397,7 +443,6 @@
         {
           'get':
             {
-              'summary': '',
               'description': 'Get method for book',
               'operationId': 'GetBook',
               'parameters':
@@ -405,14 +450,12 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -435,7 +478,6 @@
             },
           'patch':
             {
-              'summary': '',
               'description': 'Update method for book',
               'operationId': 'UpdateBook',
               'parameters':
@@ -443,14 +485,12 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -472,7 +512,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -483,7 +522,6 @@
             },
           'put':
             {
-              'summary': '',
               'description': 'Apply method for book',
               'operationId': 'ApplyBook',
               'parameters':
@@ -491,14 +529,12 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -520,7 +556,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -531,7 +566,6 @@
             },
           'delete':
             {
-              'summary': '',
               'description': 'Delete method for book',
               'operationId': 'DeleteBook',
               'parameters':
@@ -539,22 +573,18 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'force',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'boolean' },
                   },
                 ],
@@ -572,7 +602,6 @@
         {
           'get':
             {
-              'summary': '',
               'description': 'List method for book-edition',
               'operationId': 'ListBookEdition',
               'parameters':
@@ -580,29 +609,23 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'max_page_size',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'integer' },
                   },
                   {
                     'name': 'page_token',
                     'in': 'query',
-                    'description': '',
-                    'required': false,
                     'schema': { 'type': 'string' },
                   },
                 ],
@@ -637,7 +660,6 @@
             },
           'post':
             {
-              'summary': '',
               'description': 'Create method for book-edition',
               'operationId': 'CreateBookEdition',
               'parameters':
@@ -645,14 +667,12 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -676,7 +696,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -693,7 +712,6 @@
         {
           'get':
             {
-              'summary': '',
               'description': 'Get method for book-edition',
               'operationId': 'GetBookEdition',
               'parameters':
@@ -701,21 +719,18 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book-edition',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -740,7 +755,6 @@
             },
           'delete':
             {
-              'summary': '',
               'description': 'Delete method for book-edition',
               'operationId': 'DeleteBookEdition',
               'parameters':
@@ -748,21 +762,18 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book-edition',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -781,7 +792,6 @@
         {
           'post':
             {
-              'summary': '',
               'description': 'Custom method archive for book',
               'operationId': ':ArchiveBook',
               'parameters':
@@ -789,14 +799,12 @@
                   {
                     'name': 'publisher',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
                   {
                     'name': 'book',
                     'in': 'path',
-                    'description': '',
                     'required': true,
                     'schema': { 'type': 'string' },
                   },
@@ -818,7 +826,6 @@
                 },
               'requestBody':
                 {
-                  'description': '',
                   'content': { 'application/json': { 'schema': {} } },
                   'required': true,
                 },

--- a/aep/general/example.oas.yaml
+++ b/aep/general/example.oas.yaml
@@ -1,59 +1,22 @@
 {
   'openapi': '3.1.0',
   'servers': [{ 'url': 'http://localhost:8081' }],
-  'info': { 'title': 'bookstore.example.com', 'version': 'version not set' },
+  'info':
+    {
+      'title': 'bookstore.example.com',
+      'description': 'An API for bookstore.example.com',
+      'version': 'version not set',
+    },
   'paths':
     {
       '/isbns':
         {
-          'get':
-            {
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/isbn',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-              'parameters':
-                [
-                  {
-                    'in': 'query',
-                    'name': 'max_page_size',
-                    'required': true,
-                    'type': 'integer',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'page_token',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
-            },
           'post':
             {
+              'summary': '',
+              'description': 'Create method for isbn',
+              'operationId': 'CreateIsbn',
+              'parameters': [],
               'responses':
                 {
                   '200':
@@ -71,49 +34,40 @@
                 },
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content':
                     {
                       'application/json':
                         { 'schema': { '$ref': '#/components/schemas/isbn' } },
                     },
+                  'required': true,
                 },
-            },
-        },
-      '/isbns/{isbn}':
-        {
-          'get':
-            {
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/isbn' },
-                            },
-                        },
-                    },
-                },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'isbn',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
             },
         },
       '/publishers':
         {
           'get':
             {
+              'summary': '',
+              'description': 'List method for publisher',
+              'operationId': 'ListPublisher',
+              'parameters':
+                [
+                  {
+                    'name': 'max_page_size',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'integer' },
+                  },
+                  {
+                    'name': 'page_token',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
               'responses':
                 {
                   '200':
@@ -142,24 +96,13 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'query',
-                    'name': 'max_page_size',
-                    'required': true,
-                    'type': 'integer',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'page_token',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
             },
           'post':
             {
+              'summary': '',
+              'description': 'Create method for publisher',
+              'operationId': 'CreatePublisher',
+              'parameters': [],
               'responses':
                 {
                   '200':
@@ -175,18 +118,9 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'query',
-                    'name': 'id',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -195,27 +129,27 @@
                             { '$ref': '#/components/schemas/publisher' },
                         },
                     },
+                  'required': true,
                 },
             },
         },
       '/publishers/{publisher}':
         {
-          'delete':
+          'get':
             {
-              'responses': { '200': { 'description': '', 'content': null } },
+              'summary': '',
+              'description': 'Get method for publisher',
+              'operationId': 'GetPublisher',
               'parameters':
                 [
                   {
-                    'in': 'path',
                     'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
-                  { 'in': 'query', 'name': 'force', 'type': 'boolean' },
                 ],
-            },
-          'get':
-            {
               'responses':
                 {
                   '200':
@@ -231,57 +165,22 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
             },
           'patch':
             {
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/merge-patch+json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
+              'summary': '',
+              'description': 'Update method for publisher',
+              'operationId': 'UpdatePublisher',
               'parameters':
                 [
                   {
-                    'in': 'path',
                     'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                 ],
-              'requestBody':
-                {
-                  'required': true,
-                  'content':
-                    {
-                      'application/merge-patch+json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                },
-            },
-          'put':
-            {
               'responses':
                 {
                   '200':
@@ -297,18 +196,9 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -316,6 +206,82 @@
                           'schema':
                             { '$ref': '#/components/schemas/publisher' },
                         },
+                    },
+                  'required': true,
+                },
+            },
+          'put':
+            {
+              'summary': '',
+              'description': 'Apply method for publisher',
+              'operationId': 'ApplyPublisher',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
+              'responses':
+                {
+                  '200':
+                    {
+                      'description': 'Successful response',
+                      'content':
+                        {
+                          'application/json':
+                            {
+                              'schema':
+                                { '$ref': '#/components/schemas/publisher' },
+                            },
+                        },
+                    },
+                },
+              'requestBody':
+                {
+                  'description': '',
+                  'content':
+                    {
+                      'application/json':
+                        {
+                          'schema':
+                            { '$ref': '#/components/schemas/publisher' },
+                        },
+                    },
+                  'required': true,
+                },
+            },
+          'delete':
+            {
+              'summary': '',
+              'description': 'Delete method for publisher',
+              'operationId': 'DeletePublisher',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'force',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'boolean' },
+                  },
+                ],
+              'responses':
+                {
+                  '204':
+                    {
+                      'description': 'Successful response',
+                      'content': { 'application/json': { 'schema': {} } },
                     },
                 },
             },
@@ -324,6 +290,33 @@
         {
           'get':
             {
+              'summary': '',
+              'description': 'List method for book',
+              'operationId': 'ListBook',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'max_page_size',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'integer' },
+                  },
+                  {
+                    'name': 'page_token',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
               'responses':
                 {
                   '200':
@@ -346,36 +339,33 @@
                                               '$ref': '#/components/schemas/book',
                                             },
                                         },
+                                      'unreachable':
+                                        {
+                                          'type': 'array',
+                                          'items': { 'type': 'string' },
+                                        },
                                     },
                                 },
                             },
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'max_page_size',
-                    'required': true,
-                    'type': 'integer',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'page_token',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
             },
           'post':
             {
+              'summary': '',
+              'description': 'Create method for book',
+              'operationId': 'CreateBook',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
               'responses':
                 {
                   '200':
@@ -391,56 +381,42 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'id',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content':
                     {
                       'application/json':
                         { 'schema': { '$ref': '#/components/schemas/book' } },
                     },
+                  'required': true,
                 },
             },
         },
       '/publishers/{publisher}/books/{book}':
         {
-          'delete':
+          'get':
             {
-              'responses': { '200': { 'description': '', 'content': null } },
+              'summary': '',
+              'description': 'Get method for book',
+              'operationId': 'GetBook',
               'parameters':
                 [
                   {
-                    'in': 'path',
                     'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                   {
-                    'in': 'path',
                     'name': 'book',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
-                  { 'in': 'query', 'name': 'force', 'type': 'boolean' },
                 ],
-            },
-          'get':
-            {
               'responses':
                 {
                   '200':
@@ -456,66 +432,29 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'path',
-                    'name': 'book',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
             },
           'patch':
             {
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/merge-patch+json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
+              'summary': '',
+              'description': 'Update method for book',
+              'operationId': 'UpdateBook',
               'parameters':
                 [
                   {
-                    'in': 'path',
                     'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                   {
-                    'in': 'path',
                     'name': 'book',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                 ],
-              'requestBody':
-                {
-                  'required': true,
-                  'content':
-                    {
-                      'application/merge-patch+json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                },
-            },
-          'put':
-            {
               'responses':
                 {
                   '200':
@@ -531,28 +470,100 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'path',
-                    'name': 'book',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content':
                     {
                       'application/json':
                         { 'schema': { '$ref': '#/components/schemas/book' } },
+                    },
+                  'required': true,
+                },
+            },
+          'put':
+            {
+              'summary': '',
+              'description': 'Apply method for book',
+              'operationId': 'ApplyBook',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'book',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
+              'responses':
+                {
+                  '200':
+                    {
+                      'description': 'Successful response',
+                      'content':
+                        {
+                          'application/json':
+                            {
+                              'schema':
+                                { '$ref': '#/components/schemas/book' },
+                            },
+                        },
+                    },
+                },
+              'requestBody':
+                {
+                  'description': '',
+                  'content':
+                    {
+                      'application/json':
+                        { 'schema': { '$ref': '#/components/schemas/book' } },
+                    },
+                  'required': true,
+                },
+            },
+          'delete':
+            {
+              'summary': '',
+              'description': 'Delete method for book',
+              'operationId': 'DeleteBook',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'book',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'force',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'boolean' },
+                  },
+                ],
+              'responses':
+                {
+                  '204':
+                    {
+                      'description': 'Successful response',
+                      'content': { 'application/json': { 'schema': {} } },
                     },
                 },
             },
@@ -561,6 +572,40 @@
         {
           'get':
             {
+              'summary': '',
+              'description': 'List method for book-edition',
+              'operationId': 'ListBookEdition',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'book',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'max_page_size',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'integer' },
+                  },
+                  {
+                    'name': 'page_token',
+                    'in': 'query',
+                    'description': '',
+                    'required': false,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
               'responses':
                 {
                   '200':
@@ -589,36 +634,29 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'path',
-                    'name': 'book',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'max_page_size',
-                    'required': true,
-                    'type': 'integer',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'page_token',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
             },
           'post':
             {
+              'summary': '',
+              'description': 'Create method for book-edition',
+              'operationId': 'CreateBookEdition',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'book',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
               'responses':
                 {
                   '200':
@@ -636,30 +674,9 @@
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'path',
-                    'name': 'book',
-                    'required': true,
-                    'type': 'string',
-                  },
-                  {
-                    'in': 'query',
-                    'name': 'id',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content':
                     {
                       'application/json':
@@ -668,38 +685,41 @@
                             { '$ref': '#/components/schemas/book-edition' },
                         },
                     },
+                  'required': true,
                 },
             },
         },
       '/publishers/{publisher}/books/{book}/editions/{book-edition}':
         {
-          'delete':
+          'get':
             {
-              'responses': { '200': { 'description': '', 'content': null } },
+              'summary': '',
+              'description': 'Get method for book-edition',
+              'operationId': 'GetBookEdition',
               'parameters':
                 [
                   {
-                    'in': 'path',
                     'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                   {
-                    'in': 'path',
                     'name': 'book',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                   {
-                    'in': 'path',
                     'name': 'book-edition',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                 ],
-            },
-          'get':
-            {
               'responses':
                 {
                   '200':
@@ -717,33 +737,70 @@
                         },
                     },
                 },
+            },
+          'delete':
+            {
+              'summary': '',
+              'description': 'Delete method for book-edition',
+              'operationId': 'DeleteBookEdition',
               'parameters':
                 [
                   {
-                    'in': 'path',
                     'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                   {
-                    'in': 'path',
                     'name': 'book',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                   {
-                    'in': 'path',
                     'name': 'book-edition',
+                    'in': 'path',
+                    'description': '',
                     'required': true,
-                    'type': 'string',
+                    'schema': { 'type': 'string' },
                   },
                 ],
+              'responses':
+                {
+                  '204':
+                    {
+                      'description': 'Successful response',
+                      'content': { 'application/json': { 'schema': {} } },
+                    },
+                },
             },
         },
-      '/publishers/{publisher}:archive':
+      '/publishers/{publisher}/books/{book}:archive':
         {
           'post':
             {
+              'summary': '',
+              'description': 'Custom method archive for book',
+              'operationId': ':ArchiveBook',
+              'parameters':
+                [
+                  {
+                    'name': 'publisher',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                  {
+                    'name': 'book',
+                    'in': 'path',
+                    'description': '',
+                    'required': true,
+                    'schema': { 'type': 'string' },
+                  },
+                ],
               'responses':
                 {
                   '200':
@@ -754,24 +811,16 @@
                           'application/json':
                             {
                               'schema':
-                                { '$ref': '#/components/schemas/publisher' },
+                                { '$ref': '#/components/schemas/book' },
                             },
                         },
                     },
                 },
-              'parameters':
-                [
-                  {
-                    'in': 'path',
-                    'name': 'publisher',
-                    'required': true,
-                    'type': 'string',
-                  },
-                ],
               'requestBody':
                 {
-                  'required': true,
+                  'description': '',
                   'content': { 'application/json': { 'schema': {} } },
+                  'required': true,
                 },
             },
         },
@@ -783,10 +832,23 @@
           'book':
             {
               'type': 'object',
-              'required': ['isbn', 'price', 'published'],
               'properties':
                 {
-                  'author': { 'type': 'array', 'items': { 'type': 'object' } },
+                  'author':
+                    {
+                      'type': 'array',
+                      'items':
+                        {
+                          'type': 'object',
+                          'properties':
+                            {
+                              'firstName': { 'type': 'string' },
+                              'lastName': { 'type': 'string' },
+                            },
+                          'x-aep-field-numbers':
+                            { '1': 'firstName', '2': 'lastName' },
+                        },
+                    },
                   'edition': { 'type': 'integer', 'format': 'int32' },
                   'isbn': { 'type': 'array', 'items': { 'type': 'string' } },
                   'path': { 'type': 'string', 'readOnly': true },
@@ -797,14 +859,23 @@
                 {
                   'singular': 'book',
                   'plural': 'books',
-                  'patterns': ['/publishers/{publisher}/books/{book}'],
+                  'patterns': ['publishers/{publisher}/books/{book}'],
                   'parents': ['publisher'],
                 },
+              'x-aep-field-numbers':
+                {
+                  '0': 'author',
+                  '1': 'isbn',
+                  '10018': 'path',
+                  '2': 'price',
+                  '3': 'published',
+                  '4': 'edition',
+                },
+              'required': ['isbn', 'price', 'published'],
             },
           'book-edition':
             {
               'type': 'object',
-              'required': ['displayname'],
               'properties':
                 {
                   'displayname': { 'type': 'string' },
@@ -816,10 +887,12 @@
                   'plural': 'book-editions',
                   'patterns':
                     [
-                      '/publishers/{publisher}/books/{book}/editions/{book-edition}',
+                      'publishers/{publisher}/books/{book}/editions/{book-edition}',
                     ],
                   'parents': ['book'],
                 },
+              'x-aep-field-numbers': { '1': 'displayname', '10018': 'path' },
+              'required': ['displayname'],
             },
           'isbn':
             {
@@ -829,8 +902,9 @@
                 {
                   'singular': 'isbn',
                   'plural': 'isbns',
-                  'patterns': ['/isbns/{isbn}'],
+                  'patterns': ['isbns/{isbn}'],
                 },
+              'x-aep-field-numbers': { '10018': 'path' },
             },
           'publisher':
             {
@@ -844,8 +918,9 @@
                 {
                   'singular': 'publisher',
                   'plural': 'publishers',
-                  'patterns': ['/publishers/{publisher}'],
+                  'patterns': ['publishers/{publisher}'],
                 },
+              'x-aep-field-numbers': { '1': 'description', '10018': 'path' },
             },
         },
     },


### PR DESCRIPTION
The existing OpenAPI example did not adhere to 
the openapi-linter.

Some minor fixes on using the common example 
OAS proto.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

💝 Thank you!
