### PR TITLE
Add a link to the x-aep-resource extension in aep-131

### DIFF
--- a/aep/general/0131/aep.md.j2
+++ b/aep/general/0131/aep.md.j2
@@ -10,9 +10,11 @@ resource.
 
 ## Guidance
 
- - APIs **must** provide a get method for resources. The purpose of the get method
-is to return data from a single resource.
- - Some resources take longer to be retrieved than is reasonable for a regular API request. In this situation, the API should use a [long-running operation](/long-running-operations).
+- APIs **must** provide a get method for resources. The purpose of the get
+  method is to return data from a single resource.
+- Some resources take longer to be retrieved than is reasonable for a regular
+  API request. In this situation, the API should use a
+  [long-running operation](/long-running-operations).
 
 ### Operation
 
@@ -105,7 +107,10 @@ there is a reason to return a partial response (see AEP-157).
 {% sample '../example.oas.yaml', '$.paths./publishers/{publisher}/books/{book}.get.responses.200.content' %}
 
 - The response content **must** be the resource itself. For example:
-  `#/components/schemas/Book`. The response **must** reference a schema with a `x-aep-resource` extension.
+  `#/components/schemas/Book`. The response **must** reference a schema with a
+  [`x-aep-resource` extension].
+
+[`x-aep-resource` extension]: ./0004.md#annotating-resource-types
 
 {% endtabs %}
 


### PR DESCRIPTION
Just adding a link to the x-aep-resource extension.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
