### PR TITLE
add resource reference field on paths

### DIFF
--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -73,13 +73,18 @@ For OpenAPI 3.0, Resources must be defined in `#components/schemas` and use the 
             "projects/{project}/user-events/{user-event}",
             "folder/{folder}/user-events/{user-event}",
             "users/{user}/events/{user-event}"
-          ]
+          ],
+          "parents": ["project", "folder", "user"]
         }
       }
     }
   }
 }
 ```
+
+- If the resource has any parents, they must be specified in the parents field
+using the singular name of the resource. The resource must be defined with a
+`x-aep-resource` annotation.
 
 {% endtabs %}
 

--- a/aep/general/example.oas.yaml
+++ b/aep/general/example.oas.yaml
@@ -354,6 +354,9 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'max_page_size',
@@ -411,6 +414,9 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                 ],
               'responses':
@@ -452,6 +458,9 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
@@ -487,6 +496,9 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
@@ -575,6 +587,9 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
@@ -611,12 +626,18 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Book'
+                    }
                   },
                   {
                     'name': 'max_page_size',
@@ -669,12 +690,18 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Book'
+                    }
                   },
                 ],
               'responses':
@@ -721,12 +748,18 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Book'
+                    }
                   },
                   {
                     'name': 'book-edition',
@@ -764,12 +797,18 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Book'
+                    }
                   },
                   {
                     'name': 'book-edition',
@@ -801,12 +840,18 @@
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Publisher'
+                    }
                   },
                   {
                     'name': 'book',
                     'in': 'path',
                     'required': true,
                     'schema': { 'type': 'string' },
+                    'x-aep-resource-reference': {
+                      'resource': 'Book'
+                    }
                   },
                 ],
               'responses':


### PR DESCRIPTION
`x-aep-resource` establishes a list of parents. The individual API endpoints do not establish which fields correspond to a parent resource (if any). This could be established through some guessing, but it's better to annotate these fields specifically.

This introduces `x-aep-resource-reference` to indicate that a particular field represents a parent resource. This is super useful for the Resource Explorer in particular.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)


💝 Thank you!
