### PR TITLE
feat(132): clarify operator precedence

### DIFF
--- a/aep/general/0132/aep.md.j2
+++ b/aep/general/0132/aep.md.j2
@@ -154,6 +154,25 @@ with an HTTP 404 error.
 **Note:** An empty collection which the user has permission to access **must**
 return `200 OK` with an empty results array, and not `404 Not Found`.
 
+### Advanced operations
+
+`List` methods **may** allow an extended set of functionality to allow a user to
+specify the resources that are returned in a response.
+
+The following table summarizes the applicable AEPs, ordered by the precedence of
+the operation on the results.
+
+| Operation                    | AEP                               |
+| ---------------------------- | --------------------------------- |
+| filter                       | [AEP-160](/160)                   |
+| ordering (`orderBy`)         | [AEP-132](#ordering)              |
+| pagination (`nextPageToken`) | [AEP-158](/158)                   |
+| skip                         | [AEP-158](/158/#skipping-results) |
+
+For example, if both the `filter` and `skip` fields are specified, then the
+filter would be applied first, then the resulting set would be the results that
+skip N entries of the filtered result.
+
 ### Ordering
 
 `List` methods **may** allow clients to specify sorting order; if they do, the
@@ -170,16 +189,6 @@ request message **should** contain a `string orderBy` field.
 
 **Note:** Only include ordering if there is an established need to do so. It is
 always possible to add ordering later, but removing it is a breaking change.
-
-### Filtering
-
-List methods **may** allow clients to specify filters; if they do, the request
-message **should** contain a `string filter` field. Filtering is described in
-more detail in AEP-160.
-
-**Note:** Only include filtering if there is an established need to do so. It
-is always possible to add filtering later, but removing it is a breaking
-change.
 
 ### Soft-deleted resources
 


### PR DESCRIPTION
It's unclear at this point what order the various AEPs should be applied on an API endpoint, if they exist.

Adding a section to clarify this. An example of this precedence is drafted at https://github.com/aep-dev/aepc/pull/60.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
