### PR TITLE
feat(130): add guidance around OAS OperationIDs

### DIFF
--- a/aep/general/0130/aep.md.j2
+++ b/aep/general/0130/aep.md.j2
@@ -42,6 +42,30 @@ in the following order:
 1. Custom methods (on collections, resources, or stateless)
 1. Streaming methods
 
+### OperationIDs and RPC names
+
+OpenAPI Specifications specify an
+[operationId](https://spec.openapis.org/oas/latest.html#fixed-fields-7) field to
+uniquely identify an operation, as well as provide a name for the operation in
+tools and libraries.
+
+In a similar fashion, gRPC has [RPCs definition within a
+service](https://grpc.io/docs/what-is-grpc/core-concepts/#service-definition).
+
+The operationId and RPCs names **should** follow the following format:
+
+* `{standard-method-name}{resource-singular}` for non-list standard methods.
+* `List{resource-plural}` for lists.
+* `:{custom-method-name}{resource-singular}` for custom methods (omit the leading colon for gRPC).
+
+Some examples include:
+
+- `CreateBook`
+- `GetBook`
+- `ApplyBook`
+- `ListBooks`
+- `:ArchiveBook`
+
 ## Rationale
 
 Resource-oriented standard and custom methods are recommended first, as they can

--- a/aep/general/0130/aep.md.j2
+++ b/aep/general/0130/aep.md.j2
@@ -44,7 +44,7 @@ in the following order:
 
 ### OperationIDs and RPC names
 
-OpenAPI Specifications specify an
+The OpenAPI specification includes an
 [operationId](https://spec.openapis.org/oas/latest.html#fixed-fields-7) field to
 uniquely identify an operation, as well as provide a name for the operation in
 tools and libraries.


### PR DESCRIPTION
To help with more standard generation of clients,
propose a standard for OAS operation IDs.

fixes #208

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

💝 Thank you!
