### PR TITLE
chore: PR template comments out new AEP checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,9 +28,9 @@ contributing to this repository.
 - [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
       (usually `prettier -w .`)
 
-### Additional checklist for a new AEP
+<!-- uncomment this if PR is for a new AEP
 
-<!-- delete if this is not a new AEP -->
+### Additional checklist for a new AEP
 
 - [ ] A new AEP **should** be no more than two pages if printed out.
 - [ ] Ensure that the PR is editable by maintainers.
@@ -39,5 +39,7 @@ contributing to this repository.
 - [ ] Ensure that
       [Document structure](https://aep.dev/style-guide#document-structure)
       guidelines are met.
+
+-->
 
 💝 Thank you!


### PR DESCRIPTION
Often, we are making spot fixes to AEPs, and not introducing brand new ones. Therefore, the PR template should comment out new AEP guides rather than requiring it to be removed.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

💝 Thank you!
