### PR TITLE
docs: add tooling section

### DIFF
--- a/config/hero.yaml
+++ b/config/hero.yaml
@@ -19,6 +19,14 @@ shortcuts:
     button:
       href: /contributing
       text: Contribute to the project
+  - title: Want to see the tools?
+    description: |
+      AEPs provide an ecosystem of tools to help produce compliant APIs and
+      interact with them. Learn more about how the tools fit in to a development
+      workflow.
+    button:
+      href: /general/tooling-and-ecosystem
+      text: View ecosystem
   - title: Want to adopt AEPs in your organization?
     description: |
       AEPs were adapted from [Google's AIP project](https://google.aip.dev/), but also enhanced with improved

--- a/pages/general/tooling-and-ecosystem.md
+++ b/pages/general/tooling-and-ecosystem.md
@@ -1,0 +1,54 @@
+# Tooling and Ecosystem
+
+In addition to an API design specification, AEPs also provide an ecosystem of
+tooling to help produce and interact with these APIs.
+
+## Diagram
+
+The following is a diagram that illustrates an end-to-end workflow, including
+nodes of tooling that exists, or is intended to be created for the project.
+
+Some of the tools in the diagram are not maintained by the AEP project. The
+diagram is intended to be a complete representation of tools available to help
+a user understand how the tools fit in to a development workflow.
+
+```mermaid
+flowchart TD
+tool([tool])
+use-case[/possible use case/]
+user(user authored)
+generated{{generated}}
+```
+
+The service generation tooling looks like:
+
+```mermaid
+flowchart TD
+    resources("AEP Resource yaml")
+    resources --> hub(['<a href="https://github.com/aep-dev/aepc">aepc: service API generator</a>'])
+    hub --> proto{{"gRPC protobuf definition"}}
+    hub --> openapi{{"OpenAPI Schema"}}
+    hub --> graphql[/GraphQL definitions/]
+    proto --> proto-service(your proto service)
+    proto-service --> http-grpc{{"HTTP REST APIs via grpc-gateway"}}
+    proto --> proto-linter([<a href="https://github.com/aep-dev/api-linter">aep-proto-linter: lint gRPC definitons for AEP compliance.</a>])
+    openapi --> http-generated{{api stubs via openapi-generator}}
+    openapi --> oas-linter([<a href="https://github.com/aep-dev/aep-openapi-linter">aep-openapi-linter: lint OAS definitions for AEP compliance.</a>])
+    http-generated --> http-service(your http service)
+```
+
+While the client tooling for an AEP-compliant compatible API includes:
+
+```mermaid
+flowchart LR
+    http["AEP-compliant REST API and OpenAPI definition"]
+    http --> cli([<a href="https://github.com/aep-dev/aepcli">aepcli: a command-line interface for AEP-compliant APIs</a>])
+    http --> terraform_generator(["terraform provider generator (planned)"])
+    terraform_generator --> terraform{{"terraform provider"}}
+    http --> llm[/"LLM plugin (external integration)"/]
+    http --> ui([<a href="https://github.com/aep-dev/aep-explorer">aep-explorer: interactive web UI to create, edit, list, and modify resources])
+    http --> sdks[/"Language-specific libraries (e.g. via openapi-generator)"/]
+    http --> asset_inventory[/"Asset inventory and policy management tooling (external integration)"/]
+    http --> crd_generator(["Kubernetes Custom Resource Definitions generator"])
+    http --> docs(["API documentation generator (planned)"])
+```


### PR DESCRIPTION
Add a section that discusses the AEP tooling ecosystem. This will better improve the discoverability of the tools.

The site-generator does not currently support mermaid, but I think it'd be great if it did and we merge this in rather that switch to graphviz, which is missing highlighting of links.

Example render in my editor:

![20250110_22h36m16s_grim](https://github.com/user-attachments/assets/79e61a59-3493-4ec1-9855-957465aadd61)


## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
