### PR TITLE
feat(3): add terminology for root resources and collections

### DIFF
--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -82,9 +82,9 @@ be used when a statement refers broadly to both programs and users.
 
 ### Collection
 
-A collection represents a discrete set of resources of a specific type. A resource
-may have one or more collections, with each collection having its own set of
-parent collections.
+A collection represents a discrete set of resources of a specific type. A
+resource may have one or more collections, with each collection having its own
+parent.
 
 ### Declarative Clients
 
@@ -107,24 +107,25 @@ Examples of complexities that declarative clients abstract away include:
 
 ### Root collection
 
-A [collection](#collection) that does not have any parent collections. For example,
-`/users/`.
+A [collection](#collection) that does not have any parent collections. For
+example, `/users/`.
 
 ### Root Resource
 
-A root resource is a resource which has a collection that has no parents. In
-other words, it is a resource that has a collection that appears at the root of
-a resource hierarchy.
+A root resource is a resource for which a collection exists that has no
+parents. In other words, it is a resource that has a collection that appears at
+the root of a resource hierarchy.
 
 A root resource may also appear as a child of another resource: for example, a
-user permission may exist globally, but also as a child of a individual object.
-In this case, the resource is still considered a root resource, because at
-least one collection does not have a parent.
+music streaming services may have global shared playlists (e.g. "top
+trending"), but may also be nested under a user. In this case, a playlist is
+still considered a root resource, since the collection with the glocal shared
+playlists has no parents.
 
 ### Schema
 
-A schema describes the structure of the request or response of an [API
-method](#api-method), or a [resource](#api-resource). It refers both to an
+A schema describes the structure of the request or response of an
+[API method](#api-method), or a [resource](#api-resource). It refers both to an
 OpenAPI schema as well as a protobuf message.
 
 ### User

--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -118,9 +118,9 @@ the root of a resource hierarchy.
 
 A root resource may also appear as a child of another resource: for example, a
 music streaming services may have global shared playlists (e.g. "top
-trending"), but may also have playlists nested under a user. In this case, a playlist is
-still considered a root resource, since the collection with the glocal shared
-playlists has no parents.
+trending"), but may also have playlists nested under a user. In this case, a
+playlist is still considered a root resource, since the collection with the
+glocal shared playlists has no parents.
 
 ### Schema
 

--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -112,13 +112,13 @@ A [collection](#collection) that does not have any parent collections. For examp
 
 ### Root Resource
 
-A `root` resource is a resource which has a collection that has no parents. In
+A root resource is a resource which has a collection that has no parents. In
 other words, it is a resource that has a collection that appears at the root of
 a resource hierarchy.
 
 A root resource may also appear as a child of another resource: for example, a
 user permission may exist globally, but also as a child of a individual object.
-In this case, the resource is still considered a "root" resource, because at
+In this case, the resource is still considered a root resource, because at
 least one collection does not have a parent.
 
 ### Schema

--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -82,8 +82,8 @@ be used when a statement refers broadly to both programs and users.
 
 ### Collection
 
-A collection represents a discrete set of a specific resource type. A resource
-may have one or more collections, with each collection having it's own set of
+A collection represents a discrete set of resources of a specific type. A resource
+may have one or more collections, with each collection having its own set of
 parent collections.
 
 ### Declarative Clients
@@ -107,7 +107,7 @@ Examples of complexities that declarative clients abstract away include:
 
 ### Root collection
 
-A [collection](#collection) that does not have a parent collection. For example,
+A [collection](#collection) that does not have any parent collections. For example,
 `/users/`.
 
 ### Root Resource

--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -118,7 +118,7 @@ the root of a resource hierarchy.
 
 A root resource may also appear as a child of another resource: for example, a
 music streaming services may have global shared playlists (e.g. "top
-trending"), but may also be nested under a user. In this case, a playlist is
+trending"), but may also have playlists nested under a user. In this case, a playlist is
 still considered a root resource, since the collection with the glocal shared
 playlists has no parents.
 

--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -80,6 +80,12 @@ addresses.
 Either a programmatic client or a user that consumes an API. This term should
 be used when a statement refers broadly to both programs and users.
 
+### Collection
+
+A collection represents a discrete set of a specific resource type. A resource
+may have one or more collections, with each collection having it's own set of
+parent collections.
+
 ### Declarative Clients
 
 Declarative Clients, also known as Infrastructure as Code (IaC), describes a
@@ -98,6 +104,22 @@ Examples of complexities that declarative clients abstract away include:
 - Ordering of these imperative actions.
 
 [Terraform][] is an example of such a client.
+
+### Root collection
+
+A [collection](#collection) that does not have a parent collection. For example,
+`/users/`.
+
+### Root Resource
+
+A `root` resource is a resource which has a collection that has no parents. In
+other words, it is a resource that has a collection that appears at the root of
+a resource hierarchy.
+
+A root resource may also appear as a child of another resource: for example, a
+user permission may exist globally, but also as a child of a individual object.
+In this case, the resource is still considered a "root" resource, because at
+least one collection does not have a parent.
 
 ### Schema
 

--- a/aep/general/0121/aep.md.j2
+++ b/aep/general/0121/aep.md.j2
@@ -28,9 +28,10 @@ When designing an API, consider the following:
 A resource-oriented API **must** be modeled as a resource hierarchy, where each
 node is either a simple resource or a collection of resources.
 
-A _collection_ contains resources of _the same type_. For example, a publisher
-has the collection of books that it publishes. A resource usually has fields,
-and resources may have any number of sub-resources (usually collections).
+A [_collection_](./0003#collection) contains resources of _the same type_. For
+example, a publisher has the collection of books that it publishes. A resource
+usually has fields, and resources may have any number of sub-resources (usually
+collections).
 
 **Note:** While there is some conceptual alignment between storage systems and
 APIs, a service with a resource-oriented API is not necessarily a database, and


### PR DESCRIPTION
We are missing a term to describe a resource whose collection has no parents. Since this is helpful for things like building a navigation tree, define the term.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
