### PR TITLE
chore: upgrade prettier to 3.5.1

### DIFF
--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -101,8 +101,8 @@ Examples of complexities that declarative clients abstract away include:
 
 ### Schema
 
-A schema describes the structure of the request or response of an [API
-method](#api-method), or a [resource](#api-resource). It refers both to an
+A schema describes the structure of the request or response of an
+[API method](#api-method), or a [resource](#api-resource). It refers both to an
 OpenAPI schema as well as a protobuf message.
 
 ### User

--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -58,7 +58,8 @@ message Topic {
 
 {% tab oas %}
 
-For OpenAPI 3.0, Resources must be defined in `#components/schemas` and use the `x-aep-resource` extension:
+For OpenAPI 3.0, Resources must be defined in `#components/schemas` and use the
+`x-aep-resource` extension:
 
 ```json
 {
@@ -97,8 +98,7 @@ variable = "{", literal, "}";
 
 Where `literal` matches the regex `[a-z][a-z0-9\-]*[a-z0-9]`.
 
-- Patterns **must** match the possible [paths](/paths) of the
-  resource.
+- Patterns **must** match the possible [paths](/paths) of the resource.
 - Pattern variables (the segments within braces) **must** match the singular of
   the resource whose id is being matched by that value.
 

--- a/aep/general/0005/aep.md.j2
+++ b/aep/general/0005/aep.md.j2
@@ -94,7 +94,6 @@ See the following AEPs to learn more about the standard methods:
 [aep-134]: /0134
 [aep-135]: ./0135
 
-
 ## Identify custom operations
 
 To accomplish some of the user journeys, resources may need to support

--- a/aep/general/0008/aep.md.j2
+++ b/aep/general/0008/aep.md.j2
@@ -28,7 +28,8 @@ clients or their authors, including but not limited to:
 - Command line interfaces for exploration and simple automation.
 - Custom controllers (e.g. auto-scalers) which poll live state and adjust
   resource configuration accordingly.
-- [Declarative clients][] for orchestration and automation of multiple resources.
+- [Declarative clients][] for orchestration and automation of multiple
+  resources.
 - Recommendation tools which provide guidance on which APIs are useful for
   specific use cases, and how to use them.
 - SDKs to interact with an API from a programming language, often used heavily
@@ -233,7 +234,8 @@ branch.
 
 ### Error codes
 
-When referencing a error code, the prose **should** use the format `{google.api.error_code} / {http_status_code}`. For example, `OK / 200`.
+When referencing a error code, the prose **should** use the format
+`{google.api.error_code} / {http_status_code}`. For example, `OK / 200`.
 
 ## Rationale
 

--- a/aep/general/0121/aep.md.j2
+++ b/aep/general/0121/aep.md.j2
@@ -89,13 +89,13 @@ A method is strongly consistent if, upon completion of a request of that method
 will return the same value on any subsequent requests until another request
 which mutates the resource is completed.
 
-[Output only][output only] fields unrelated to the resource [state][] **should**
-also return the same value on each subsequent request until another request
-which mutates the resource is completed.
+[Output only][output only] fields unrelated to the resource [state][]
+**should** also return the same value on each subsequent request until another
+request which mutates the resource is completed.
 
-- An [output only][] field that takes so long to reach a steady-state that it would
-  negatively impact the user experience of the request (e.g. an hour-long instantiation
-  of a VM cluster).
+- An [output only][] field that takes so long to reach a steady-state that it
+  would negatively impact the user experience of the request (e.g. an hour-long
+  instantiation of a VM cluster).
 
 Examples of strong consistency include:
 
@@ -109,15 +109,15 @@ Examples of strong consistency include:
   the `DELETED` state value in the case of [soft delete][])
 
 Clients of resource-oriented APIs often need to orchestrate multiple operations
-in sequence (e.g., create resource A, create resource B which depends on A), and
-ensuring that resources immediately reflect steady user state after an
+in sequence (e.g., create resource A, create resource B which depends on A),
+and ensuring that resources immediately reflect steady user state after an
 operation is complete ensures clients can rely on method completion as a signal
 to begin the next operation.
 
-[Output only][output only] fields ideally would follow the same guidelines, but as these
-fields can often represent a resources live state, it's sometimes necessary for
-these values to change after a successful mutation operation to reflect a state
-change.
+[Output only][output only] fields ideally would follow the same guidelines, but
+as these fields can often represent a resources live state, it's sometimes
+necessary for these values to change after a successful mutation operation to
+reflect a state change.
 
 ### Cyclic References
 

--- a/aep/general/0124/aep.md.j2
+++ b/aep/general/0124/aep.md.j2
@@ -24,7 +24,6 @@ associated with other resources through other fields on the resource.
 
 {% sample 'multiple_many_to_one.oas.yaml', '$.components.schema.Book' %}
 
-
 {% endtabs %}
 
 When listing resources with multiple associations in this way, the RPC **must**

--- a/aep/general/0127/aep.md.j2
+++ b/aep/general/0127/aep.md.j2
@@ -9,11 +9,11 @@ accustomed to that pattern.
 
 ## Guidance
 
-Protobuf APIs **must** provide HTTP definitions for each RPC that they define, except
-for bi-directional streaming RPCs, which can not be natively supported using
-HTTP/1.1. When providing a bi-directional streaming method, an API **should**
-also offer an alternative method that does not rely on bi-directional
-streaming.
+Protobuf APIs **must** provide HTTP definitions for each RPC that they define,
+except for bi-directional streaming RPCs, which can not be natively supported
+using HTTP/1.1. When providing a bi-directional streaming method, an API
+**should** also offer an alternative method that does not rely on
+bi-directional streaming.
 
 ### HTTP method and path
 
@@ -56,16 +56,16 @@ message CreateBookRequest {
 - The first key (`post` in this example) corresponds to the HTTP method. RPCs
   **may** use `get`, `post`, `patch`, or `delete`.
   - RPCs **must** use the prescribed HTTP verb for each standard method, as
-    discussed in [Get](/get), [List](/list), [Create](/create), [Update](/update), and
-    [Delete](/delete)
+    discussed in [Get](/get), [List](/list), [Create](/create),
+    [Update](/update), and [Delete](/delete)
   - RPCs **should** use the prescribed HTTP verb for custom methods, as
     discussed in [Custom Methods](/custom-methods).
   - RPCs **should not** use `put` or `custom`.
 - The corresponding value represents the URI.
   - URIs **must** use the `{foo=bar/*}` syntax to represent a variable that
-    should be populated in the request proto. When extracting a [resource
-    name](/resource-paths), the variable **must** include the entire resource name, not
-    just the ID component.
+    should be populated in the request proto. When extracting a
+    [resource name](/resource-paths), the variable **must** include the entire
+    resource name, not just the ID component.
   - URIs **may** use nested fields for their variable names. (Additionally,
     AEP-134 mandates this for `Update` requests.)
   - URIs **must** use the `*` character to represent ID components, which
@@ -77,9 +77,10 @@ message CreateBookRequest {
   as defined by protocol buffers' canonical [JSON encoding][json encoding].
   - RPCs **must not** define a `body` at all for RPCs that use the `GET` or
     `DELETE` HTTP verbs.
-  - RPCs **must** use the prescribed `body` for Create ([Create](/create)) and Update
-    ([AEP-134](/update)) requests.
-  - RPCs **should** use the prescribed `body` for custom methods ([Custom Methods](custom-methods)).
+  - RPCs **must** use the prescribed `body` for Create ([Create](/create)) and
+    Update ([AEP-134](/update)) requests.
+  - RPCs **should** use the prescribed `body` for custom methods
+    ([Custom Methods](custom-methods)).
   - The `body` **must not** contain a nested field (or use the `.` character),
   - The `body` **must not** be the same as a URI parameter.
   - The `body` **must not** be a `repeated` field.

--- a/aep/general/0130/aep.md.j2
+++ b/aep/general/0130/aep.md.j2
@@ -13,23 +13,23 @@ operates upon.
 
 | Category Name                                                                                                                                                                                                                                         | Related AIPs                                                | [Declarative client][] integration | CLI / UI integration | SDK integration |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------- | -------------------- | --------------- |
-| *Standard Methods*                                                                                                                                                                                                                                    |                                                             |                                    |                      |                 |
+| _Standard Methods_                                                                                                                                                                                                                                    |                                                             |                                    |                      |                 |
 | **Standard collection methods**: operate on a collection of resources (List or Create).                                                                                                                                                               | [resources], [list], [create]                               | automatable                        | automatable          | automatable     |
 | **Standard resource methods**: fetch or mutate a single resource (Get, Update, Delete).                                                                                                                                                               | [resources], [get], [update], [delete]                      | automatable                        | automatable          | automatable     |
 | **Batch resource methods**: fetch or mutate multiple resources in a collection by name.                                                                                                                                                               | [batch-get], [batch-create], [batch-update], [batch-delete] | may be used to optimize queries    | automatable          | automatable     |
 | **Aggregated list methods**: fetch or mutate multiple resources of the same type across multiple collections.                                                                                                                                         | [reading-across-collections]                                | not useful nor automatable         | automatable          | automatable     |
-| *Custom Fetch Methods*                                                                                                                                                                                                                                |                                                             |                                    |                      |                 |
+| _Custom Fetch Methods_                                                                                                                                                                                                                                |                                                             |                                    |                      |                 |
 | **Custom collection fetch methods**: fetch information across a collection that cannot be expressed via a standard method.                                                                                                                            | [custom-methods]                                            | handwritten                        | automatable          | automatable     |
 | **Custom resource fetch methods**: fetch information for a single resource that cannot be expressed via a standard method.                                                                                                                            | [custom-methods]                                            | handwritten                        | automatable          | automatable     |
-| *Custom Mutation Methods*                                                                                                                                                                                                                             |                                                             |                                    |                      |                 |
+| _Custom Mutation Methods_                                                                                                                                                                                                                             |                                                             |                                    |                      |                 |
 | **Backing up a resource**: storing a copy of a resource at a particular point in time.                                                                                                                                                                | [resource-revisions]                                        | unused or handwritten              | automatable          | automatable     |
 | **Restoring a resource**: setting a resource to a version from a particular point in time.                                                                                                                                                            | [resource-revisions]                                        | unused or handwritten              | automatable          | automatable     |
 | **Renaming a resource**: modify the resource's name or id while preserving configuration and data.                                                                                                                                                    | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
 | **Custom collection mutation methods**: perform an imperative operation referencing a collection that may mutate one or more resources within that collection in fashion that cannot be easily achieved by standard methods (e.g. state transitions). | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
 | **Custom resource mutation methods**: perform an imperative operation on a resource that may mutate it in a way a standard method cannot (e.g. state transitions).                                                                                    | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
-| *Misc Custom Methods*                                                                                                                                                                                                                                 |                                                             |                                    |                      |
+| _Misc Custom Methods_                                                                                                                                                                                                                                 |                                                             |                                    |                      |
 | **Stateless Methods**: a method that has no permanent effect on any data within the API (e.g. translating text)                                                                                                                                       | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
-| *None of the above*                                                                                                                                                                                                                                   |                                                             |                                    |                      |                 |
+| _None of the above_                                                                                                                                                                                                                                   |                                                             |                                    |                      |                 |
 | **Streaming methods**: methods that communicate via client, server, or bi-directional streams.                                                                                                                                                        |                                                             | handwritten                        | handwritten          | automatable     |
 
 ### Choosing a method category
@@ -45,18 +45,19 @@ in the following order:
 ### OperationIDs and RPC names
 
 The OpenAPI specification includes an
-[operationId](https://spec.openapis.org/oas/latest.html#fixed-fields-7) field to
-uniquely identify an operation, as well as provide a name for the operation in
-tools and libraries.
+[operationId](https://spec.openapis.org/oas/latest.html#fixed-fields-7) field
+to uniquely identify an operation, as well as provide a name for the operation
+in tools and libraries.
 
-In a similar fashion, gRPC has [RPCs definition within a
-service](https://grpc.io/docs/what-is-grpc/core-concepts/#service-definition).
+In a similar fashion, gRPC has
+[RPCs definition within a service](https://grpc.io/docs/what-is-grpc/core-concepts/#service-definition).
 
 The operationId and RPCs names **should** follow the following format:
 
-* `{standard-method-name}{resource-singular}` for non-list standard methods.
-* `List{resource-plural}` for lists.
-* `:{custom-method-name}{resource-singular}` for custom methods (omit the leading colon for gRPC).
+- `{standard-method-name}{resource-singular}` for non-list standard methods.
+- `List{resource-plural}` for lists.
+- `:{custom-method-name}{resource-singular}` for custom methods (omit the
+  leading colon for gRPC).
 
 Some examples include:
 
@@ -68,23 +69,23 @@ Some examples include:
 
 ## Rationale
 
-Resource-oriented standard and custom methods are recommended first, as they can
-be expressed in the widest variety of clients (Declarative clients, CLIs, UIs, and so on), and
-offer the most uniform experience that allows users to apply their knowledge of
-one API to another.
+Resource-oriented standard and custom methods are recommended first, as they
+can be expressed in the widest variety of clients (Declarative clients, CLIs,
+UIs, and so on), and offer the most uniform experience that allows users to
+apply their knowledge of one API to another.
 
 If a standard method is unsuitable, then custom methods (that are mounted to a
-resource or collection) offer a lesser, but still valuable level of consistency,
-helping the user reason about the scope of the action and the object whose
-configuration is read to inform that action. Although mutative custom methods
-are not uniform enough to have an automated integration with exclusively
-resource-oriented clients such as [Declarative clients][], they are still a pattern that
-can be easily recognized by CLIs, UIs, and SDKs.
+resource or collection) offer a lesser, but still valuable level of
+consistency, helping the user reason about the scope of the action and the
+object whose configuration is read to inform that action. Although mutative
+custom methods are not uniform enough to have an automated integration with
+exclusively resource-oriented clients such as [Declarative clients][], they are
+still a pattern that can be easily recognized by CLIs, UIs, and SDKs.
 
-If one cannot express their APIs in a resource-oriented fashion at all, then the
-operation falls in a category where the lack of uniformity makes it difficult
-for any client aside from SDKs to model the operation. This category is
-preferred last due to the fact that a user cannot rely on their knowledge of
+If one cannot express their APIs in a resource-oriented fashion at all, then
+the operation falls in a category where the lack of uniformity makes it
+difficult for any client aside from SDKs to model the operation. This category
+is preferred last due to the fact that a user cannot rely on their knowledge of
 similar APIs, as well as the issue that integration with many clients will
 likely have to be hand-written.
 

--- a/aep/general/0132/aep.md.j2
+++ b/aep/general/0132/aep.md.j2
@@ -97,6 +97,7 @@ when the REST/JSON interface is used.
 
 `List` operations **must** return a page of results, with each individual
 result being a resource.
+
 - The array of resources **must** be named `results` and contain resources with
   no additional wrapping.
 - The `string nextPageToken` field **must** be included in the list response
@@ -156,11 +157,11 @@ return `200 OK` with an empty results array, and not `404 Not Found`.
 
 ### Advanced operations
 
-`List` methods **may** allow an extended set of functionality to allow a user to
-specify the resources that are returned in a response.
+`List` methods **may** allow an extended set of functionality to allow a user
+to specify the resources that are returned in a response.
 
-The following table summarizes the applicable AEPs, ordered by the precedence of
-the operation on the results.
+The following table summarizes the applicable AEPs, ordered by the precedence
+of the operation on the results.
 
 | Operation                    | AEP                               |
 | ---------------------------- | --------------------------------- |

--- a/aep/general/0133/aep.md.j2
+++ b/aep/general/0133/aep.md.j2
@@ -11,9 +11,9 @@ resource.
 
 ## Guidance
 
-APIs **should** provide a create method for resources unless it is
-not valuable for users to do so. The purpose of the create method is to create
-a new resource in an already-existing collection.
+APIs **should** provide a create method for resources unless it is not valuable
+for users to do so. The purpose of the create method is to create a new
+resource in an already-existing collection.
 
 ### Operation
 
@@ -21,8 +21,8 @@ Create methods are specified using the following pattern:
 
 - The HTTP verb **must** be `POST`.
 - Some resources take longer to be created than is reasonable for a regular API
-  request. In this situation, the API **should** use a [long-running
-  operation](/long-running-operations).
+  request. In this situation, the API **should** use a
+  [long-running operation](/long-running-operations).
 
 {% tab proto %}
 
@@ -142,8 +142,8 @@ publishers/012345678-abcd-cdef/books/12341234-5678-abcd
 
 {% tab proto %}
 
-- There **should** be exactly one `google.api.method_signature` annotation, with
-  a comma-delimited list of values, including the field representing the
+- There **should** be exactly one `google.api.method_signature` annotation,
+  with a comma-delimited list of values, including the field representing the
   resource.
   - If the collection has a parent, the list must include `parent`.
   - If the resource supports user-settable ids, the list must include `id`.

--- a/aep/general/0134/aep.md.j2
+++ b/aep/general/0134/aep.md.j2
@@ -23,8 +23,8 @@ changes to the resources without causing side effects.
   **should** be `PATCH`.
 - The operation **must** have [strong consistency][].
 - Some resources take longer to be created than is reasonable for a regular API
-  request. In this situation, the API should use a [long-running
-  operation](/long-running-operations).
+  request. In this situation, the API should use a
+  [long-running operation](/long-running-operations).
 - The response schema **must** be the resource itself.
   - The response **should** include the fully-populated resource, and **must**
     include any fields that were sent and included in the update mask unless
@@ -41,8 +41,7 @@ Update methods are specified using the following pattern:
 - The request schema's name **must** exactly match the RPC name, with a
   `Request` suffix.
 - The request's `path` field **must** map to the URI path.
-  - The `path` field **must** be the only variable in the URI
-    path.
+  - The `path` field **must** be the only variable in the URI path.
 - There **must** be a `body` key in the `google.api.http` annotation, and it
   **must** map to the resource field in the request message.
   - All remaining fields **should** map to URI query parameters.
@@ -84,9 +83,9 @@ Update methods implement a common request pattern:
 {% sample '../example.proto', 'message UpdateBookRequest' %}
 
 - A `path` field **must** be included.
-  - The field **must** be [annotated as required](/field-behavior-documentation).
-  - The field **must** identify the [resource type][aep-4] that it
-    references.
+  - The field **must** be
+    [annotated as required](/field-behavior-documentation).
+  - The field **must** identify the [resource type][aep-4] that it references.
 - The request message field for the resource **must** map to the `PATCH` body.
 - The request message field for the resource **should** be [annotated as
   required][aep-203].
@@ -180,11 +179,12 @@ would wipe out data because the previous version did not know about it.
 AEP recommends a specific diverence in behavior between the proto and the HTTP
 interfaces. Specifically:
 
-- The inclusion of the `update_mask` in the proto variant, requiring the user to
-  explicitly specify fields to be updated.
+- The inclusion of the `update_mask` in the proto variant, requiring the user
+  to explicitly specify fields to be updated.
 - The usage of [IETF RFC 7396 - Json Merge Patch][IETF RFC 7396] for HTTP APIs.
 
-This divergence in behavior is intentional, and exists for the following reasons:
+This divergence in behavior is intentional, and exists for the following
+reasons:
 
 1. The update mask is a proto-specific concept, due to the lack of ability
    across all proto versions to differentiate if the user has explicitly
@@ -193,10 +193,10 @@ This divergence in behavior is intentional, and exists for the following reasons
    field mask + proto pair and json to be translatable.
 2. RFC 7396 is a popular and well-understood standard for HTTP. Introducing a
    new standard for HTTP would have made the AEP HTTP variant less idiomatic.
-3. For HTTP-proto bindings, there is a way to generate the proto field mask from
-   the fields present in the JSON request. This is what is recommended in the
-   [API Design Patterns book, section 8.2
-   ](https://www.oreilly.com/library/view/api-design-patterns/9781617295850/),
+3. For HTTP-proto bindings, there is a way to generate the proto field mask
+   from the fields present in the JSON request. This is what is recommended in
+   the
+   [API Design Patterns book, section 8.2 ](https://www.oreilly.com/library/view/api-design-patterns/9781617295850/),
    describing the Google AIPs from which AEP-134 is forked. Implementations of
    gateway-grpc proto bindings such as
    [gateway-grpc](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/)
@@ -287,8 +287,6 @@ and omit the rest. APIs that do this **must** document this behavior.
 {% sample '../example.oas.yaml', '$.paths./publishers/{publisher}/books/{book}.patch' %}
 
 {% endtabs %}
-
-
 
 <!-- prettier-ignore-start -->
 [aep-4]: ./0004.md

--- a/aep/general/0135/aep.md.j2
+++ b/aep/general/0135/aep.md.j2
@@ -75,8 +75,7 @@ Delete methods implement a common request pattern:
 
 - A `path` field **must** be included. It **should** be called `path`.
   - The field **should** be [annotated as required][aep-203].
-  - The field **must** identify the [resource type][aep-4] that it
-    references.
+  - The field **must** identify the [resource type][aep-4] that it references.
 - The comment for the field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this

--- a/aep/general/0137/aep.md.j2
+++ b/aep/general/0137/aep.md.j2
@@ -8,15 +8,15 @@ replace a resource.
 method. These operations accept the resource and its path, which it uses to
 create or replace the resource. The operation returns the final resource.
 
-Also see the [update](/update) method, with guidance on how to implement `PATCH`
-requests.
+Also see the [update](/update) method, with guidance on how to implement
+`PATCH` requests.
 
 ## Guidance
 
-APIs **should** provide an apply method for a resource unless it is not valuable
-for users to do so. Clients should also consider using [update](/update) methods
-instead to ensure forwards compatible requests (see [PATCH and
-PUT](#patch-and-put)).
+APIs **should** provide an apply method for a resource unless it is not
+valuable for users to do so. Clients should also consider using
+[update](/update) methods instead to ensure forwards compatible requests (see
+[PATCH and PUT](#patch-and-put)).
 
 ### Operation
 
@@ -24,9 +24,10 @@ Apply methods are specified using the following pattern:
 
 - The HTTP verb **must** be `PUT`.
 - Some resources take longer to be applied than is reasonable for a regular API
-  request. In this situation, the API **should** use a [long-running
-  operation](/long-running-operations).
-- The operation **must** have [strong consistency](/resources#strong-consistency).
+  request. In this situation, the API **should** use a
+  [long-running operation](/long-running-operations).
+- The operation **must** have
+  [strong consistency](/resources#strong-consistency).
 - The HTTP URI path of the `PUT` method **must** be the resource path.
 
 {% tab proto %}
@@ -43,7 +44,7 @@ Apply methods are specified using the following pattern:
 - The method's name **must** begin with the word `Apply`. The remainder of the
   method name **should** be the singular form of the resource being applied.
 - The request's `path` field **must** map to the URI path.
- - The `path` field **must** be the only variable in the URI path.
+- The `path` field **must** be the only variable in the URI path.
 
 {% tab oas %}
 
@@ -73,9 +74,10 @@ Apply methods implement a common request message pattern:
 {% sample '../example.proto', 'message ApplyBookRequest' %}
 
 - A `path` field specifying the path of the resource **must** be included.
-  - The field **must** be [annotated as `REQUIRED`](/field-behavior-documentation).
-  - The field **must** identify the [resource type](/resource-types) of the resource
-    being applied.
+  - The field **must** be
+    [annotated as `REQUIRED`](/field-behavior-documentation).
+  - The field **must** identify the [resource type](/resource-types) of the
+    resource being applied.
 
 {% tab oas %}
 
@@ -105,8 +107,8 @@ Apply methods implement a common request message pattern:
 
 ### Errors
 
-See [errors](/errors), in particular [when to use PERMISSION_DENIED and NOT_FOUND
-errors](/errors#permission-denied).
+See [errors](/errors), in particular
+[when to use PERMISSION_DENIED and NOT_FOUND errors](/errors#permission-denied).
 
 ### PATCH and PUT
 

--- a/aep/general/0144/aep.md.j2
+++ b/aep/general/0144/aep.md.j2
@@ -72,10 +72,10 @@ back. This is fine for many situations, particularly when the array field is
 expected to have a small size (fewer than 10 or so) and race conditions are not
 an issue, or can be guarded against with [ETags][aep-154].
 
-**Note:** Declarative-friendly resources **must** use the standard
-`Update` method, and not introduce `Add` and `Remove` methods. If declarative
-tools need to reason about particular relationships while ignoring others,
-consider using a subresource instead.
+**Note:** Declarative-friendly resources **must** use the standard `Update`
+method, and not introduce `Add` and `Remove` methods. If declarative tools need
+to reason about particular relationships while ignoring others, consider using
+a subresource instead.
 
 If atomic modifications are required, and if the array is functionally a set
 (meaning that order does not matter, duplicate values are not meaningful, and
@@ -164,4 +164,3 @@ subresource instead.
   - The field **should** be designated as required.
 
 {% endtabs %}
-

--- a/aep/general/0148/aep.md.j2
+++ b/aep/general/0148/aep.md.j2
@@ -55,8 +55,8 @@ family name is not placed last in many cultures.
 
 ### Timestamps
 
-See [common components](/common-components) for more information about `Timestamp` and
-`Duration`.
+See [common components](/common-components) for more information about
+`Timestamp` and `Duration`.
 
 #### create_time
 
@@ -79,7 +79,8 @@ when the user requested deletion, or when the service successfully soft deleted
 the resource. If a resource is not soft deleted, the `delete_time` field
 **must** be empty.
 
-Resources that support [soft delete](/soft-delete) **should** provide this field.
+Resources that support [soft delete](/soft-delete) **should** provide this
+field.
 
 #### expire_time
 
@@ -110,7 +111,8 @@ A field that represents an IP address **must** comply with the following:
 - use the name `ip_address` or end with the suffix `_ip_address` e.g.
   `resolved_ip_address`
 - specify the IP address version format via one of the supported formats
-  `IPV4`, `IPV6`, or if it can be either, `IPV4_OR_IPV6` (see [fields](/fields)).
+  `IPV4`, `IPV6`, or if it can be either, `IPV4_OR_IPV6` (see
+  [fields](/fields)).
 
 #### uid
 

--- a/aep/general/0151/aep.md.j2
+++ b/aep/general/0151/aep.md.j2
@@ -37,8 +37,8 @@ Protocol buffer APIs **must** use the common component
 
 {% tab oas %}
 
-OpenAPI services **must** use this [`JSON Schema Operation`][JSON Schema
-Operation] schema.
+OpenAPI services **must** use this
+[`JSON Schema Operation`][JSON Schema Operation] schema.
 
 {% endtabs %}
 

--- a/aep/general/0154/aep.md.j2
+++ b/aep/general/0154/aep.md.j2
@@ -60,9 +60,9 @@ current ETag. If the `If-Match` header value does not match the ETag, the
 service **must** reply with an HTTP 412 error.
 
 If the user omits the `If-Match` header, the service **should** permit the
-request. However, services with [strong consistency][] or parallelism requirements
-**may** require users to send ETags all the time and reject the request with an
-HTTP 400 error if it does not contain an ETag.
+request. However, services with [strong consistency][] or parallelism
+requirements **may** require users to send ETags all the time and reject the
+request with an HTTP 400 error if it does not contain an ETag.
 
 If any conditional headers are supported for any operation within a service,
 the same conditional headers **must** be supported for all mutation methods
@@ -75,8 +75,8 @@ If a server recieves a conditional header it does not support, the service
 If any validator or conditional headers are supported for any operations in the
 service, the use of unsupported conditional headers **must** result in a
 `INVALID_ARGUMENT / 400` error response. (In other words, once a service gives
-the client reason to believe it understands conditional headers, it **must not**
-ever ignore them.)
+the client reason to believe it understands conditional headers, it **must
+not** ever ignore them.)
 
 ### Read requests
 
@@ -122,12 +122,14 @@ not equivalent to the old one).
 
 ## Changelog
 
-- **2025-01-18**: Updated to use RFC 9110 instead of RFC 7232, which is deprecated.
+- **2025-01-18**: Updated to use RFC 9110 instead of RFC 7232, which is
+  deprecated.
 - **2020-09-02**: Clarified that other errors may take precedence over
   `FAILED_PRECONDITION` for ETag mismatches.
 - **2020-09-02**: Add guidance for ETags on request messages.
 - **2019-09-23**: Changed the title to "resource freshness validation".
 
 [RFC 9110]: https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3
-[RFC 9110 Etags Comparison]: https://www.rfc-editor.org/rfc/rfc9110.html#name-comparison-2
+[RFC 9110 Etags Comparison]:
+  https://www.rfc-editor.org/rfc/rfc9110.html#name-comparison-2
 [strong consistency]: ./0121.md#strong-consistency

--- a/aep/general/0156/aep.md.j2
+++ b/aep/general/0156/aep.md.j2
@@ -13,6 +13,7 @@ per parent.
 For example:
 
 {% tab proto %}
+
 ```proto
 message Config {
   option (google.api.resource) = {
@@ -71,7 +72,7 @@ paths:
     get:
       operationId: getUserConfig
       parameters:
-      - $ref: '#/components/parameters/user'
+        - $ref: '#/components/parameters/user'
       responses:
         '200':
           content:
@@ -81,7 +82,7 @@ paths:
     patch:
       operationId: updateUserConfig
       parameters:
-      - $ref: '#/components/parameters/user'
+        - $ref: '#/components/parameters/user'
       requestBody:
         content:
           application/json:
@@ -118,8 +119,8 @@ paths:
     collection **should** be the `plural` form of the Singleton resource e.g.
     `/v1/{parent=users/*}/configs`.
   - If a parent resource ID is provided instead of the hyphen `-` as per
-    [AEP-159][aep-159], then the service **should** return a collection of one Singleton
-    resource corresponding to the specified parent resource.
+    [AEP-159][aep-159], then the service **should** return a collection of one
+    Singleton resource corresponding to the specified parent resource.
 
 {% tab proto %}
 
@@ -177,16 +178,15 @@ paths:
 
 ### Support for Standard List
 
-While Singleton resources are not directly part of a collection themselves, they
-can be viewed as part of their parent's collection. The one-to-one relationship
-of parent-to-singleton means that for every one parent there is one singleton
-instance, naturally enabling some collection-based methods when combined with
-the pattern of [Reading Across Collections][aep-159]. The Singleton can present
-as a collection to the API consumer as it is indirectly one based on its parent.
-Furthermore, presenting the Singleton resource as a pseudo-collection in such
-methods enables future expansion to a real collection, should a Singleton be
-found lacking.
-
+While Singleton resources are not directly part of a collection themselves,
+they can be viewed as part of their parent's collection. The one-to-one
+relationship of parent-to-singleton means that for every one parent there is
+one singleton instance, naturally enabling some collection-based methods when
+combined with the pattern of [Reading Across Collections][aep-159]. The
+Singleton can present as a collection to the API consumer as it is indirectly
+one based on its parent. Furthermore, presenting the Singleton resource as a
+pseudo-collection in such methods enables future expansion to a real
+collection, should a Singleton be found lacking.
 
 [aep-122]: ./0122.md
 [aep-131]: ./0131.md

--- a/aep/general/0158/aep.md.j2
+++ b/aep/general/0158/aep.md.j2
@@ -8,9 +8,9 @@ be paginated.
 
 ## Guidance
 
-Methods returning collections of data **must** provide pagination _at the outset_,
-as it is a [backwards-incompatible change](#backwards-compatibility) to add
-pagination to an existing method.
+Methods returning collections of data **must** provide pagination _at the
+outset_, as it is a [backwards-incompatible change](#backwards-compatibility)
+to add pagination to an existing method.
 
 {% tab proto %}
 
@@ -50,8 +50,8 @@ message ListBooksResponse {
 }
 ```
 
-- The field containing pagination results **should** be the first field in
-  the message and have a field number of `1`.
+- The field containing pagination results **should** be the first field in the
+  message and have a field number of `1`.
 
 {% tab oas %}
 
@@ -60,39 +60,39 @@ message ListBooksResponse {
 {% endtabs %}
 
 - Request messages for collections **should** define an integer (`int32` for
-protobuf) `max_page_size` field, allowing users to specify the maximum number of
-results to return.
+  protobuf) `max_page_size` field, allowing users to specify the maximum number
+  of results to return.
   - If the user does not specify `max_page_size` (or specifies `0`), the API
     chooses an appropriate default, which the API **should** document. The API
     **must not** return an error.
-  - If the user specifies `max_page_size` greater than the maximum permitted by the
-    API, the API **should** coerce down to the maximum permitted page size.
-  - If the user specifies a negative value for `max_page_size`, the API **must**
-    send an `INVALID_ARGUMENT` error.
+  - If the user specifies `max_page_size` greater than the maximum permitted by
+    the API, the API **should** coerce down to the maximum permitted page size.
+  - If the user specifies a negative value for `max_page_size`, the API
+    **must** send an `INVALID_ARGUMENT` error.
   - The API **may** return fewer results than the number requested (including
     zero results), even if not at the end of the collection.
 - Request schemas for collections **should** define a `string page_token`
   field, allowing users to advance to the next page in the collection.
   - The `page_token` field **must not** be required.
-  - If the user changes the `max_page_size` in a request for subsequent pages, the
-    service **must** honor the new page size.
+  - If the user changes the `max_page_size` in a request for subsequent pages,
+    the service **must** honor the new page size.
   - The user is expected to keep all other arguments to the method the same; if
     any arguments are different, the API **should** send an `INVALID_ARGUMENT`
     error.
 - The response **must not** be a streaming response.
-- Response messages for collections **must** define a
-  `string next_page_token` field, providing the user with a page token that may
-  be used to retrieve the next page.
-  - The field containing pagination results **must** be a repeated
-    field containing a list of resources constituting a single page of results.
+- Response messages for collections **must** define a `string next_page_token`
+  field, providing the user with a page token that may be used to retrieve the
+  next page.
+  - The field containing pagination results **must** be a repeated field
+    containing a list of resources constituting a single page of results.
   - If the end of the collection has been reached, the `next_page_token` field
     **must** be empty. This is the _only_ way to communicate
     "end-of-collection" to users.
   - If the end of the collection has not been reached (or if the API can not
     determine in time), the API **must** provide a `next_page_token`.
 - Response messages for collections **may** provide an integer (`int32` for
-protobuf) `total_size` field, providing the user with the total number of items
-in the list.
+  protobuf) `total_size` field, providing the user with the total number of
+  items in the list.
   - This total **may** be an estimate. If so, the API **should** explicitly
     document that.
 
@@ -150,8 +150,8 @@ is three days.
 
 ### Backwards compatibility
 
-Adding pagination to an existing method is a backwards-incompatible change. This
-may seem strange; adding fields to proto messages is generally backwards
+Adding pagination to an existing method is a backwards-incompatible change.
+This may seem strange; adding fields to proto messages is generally backwards
 compatible. However, this change is _behaviorally_ incompatible.
 
 Consider a user whose collection has 75 resources, and who has already written

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -20,13 +20,13 @@ APIs **may** expose a revision history for a resource. Examples of when it is
 useful include:
 
 - When it is valuable to expose older revisions of a resource via an API. This
-  can avoid the overhead of the customers having to write their own API to store
-  and enable retrieval of revisions.
+  can avoid the overhead of the customers having to write their own API to
+  store and enable retrieval of revisions.
 - Other resources depend on or descend from different revisions of a resource.
 - There is a need to represent the change of a resource over time.
 
-APIs implementing resources with revisions **must** model resource
-revisions as a subresource of the resource.
+APIs implementing resources with revisions **must** model resource revisions as
+a subresource of the resource.
 
 {% tab proto %}
 
@@ -56,30 +56,30 @@ message BookRevision {
 
 ```json
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "path": {
-            "type": "string"
-        },
-        "resource": {
-            "$ref": "#/definitions/Book",
-            "readOnly": true,
-        },
-        "create_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true,
-        },
-        "aliases": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "readOnly": true,
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
     },
-    "required": ["path"],
+    "resource": {
+      "$ref": "#/definitions/Book",
+      "readOnly": true
+    },
+    "create_time": {
+      "type": "string",
+      "format": "date-time",
+      "readOnly": true
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "readOnly": true
+    }
+  },
+  "required": ["path"]
 }
 ```
 
@@ -87,11 +87,13 @@ message BookRevision {
 
 - The resource revision **must** contain a field with a message type of the
   parent resource, with a field name of `resource`.
-    - The value of `resource` **must** be the original resource
-      at the point in time the revision was created.
-- The resource revision **must** contain a `create_time` field (see [AIP-142][]).
+  - The value of `resource` **must** be the original resource at the point in
+    time the revision was created.
+- The resource revision **must** contain a `create_time` field (see
+  [AIP-142][]).
 - The resource revision **may** contain a repeated field `aliases`, which would
-  contain a list of resource IDs that the revision is also known by (e.g. `latest`)
+  contain a list of resource IDs that the revision is also known by (e.g.
+  `latest`)
 
 ### Creating Revisions
 
@@ -109,19 +111,21 @@ Resources that support revisions **should** always have at least one revision.
 
 ### Resource names for revisions
 
-When referring to the revisions of a resource, the subcollection name
-**must** be `revisions`. Resource revisions have paths with the format
+When referring to the revisions of a resource, the subcollection name **must**
+be `revisions`. Resource revisions have paths with the format
 `{resource_path}/revisions/{resource_revision}`. For example:
+
 ```
 publishers/123/books/les-miserables/revisions/c7cfa2a8
 ```
 
-The resource **must** be named `{resource_singular}Revision` (for example, `BookRevision`).
+The resource **must** be named `{resource_singular}Revision` (for example,
+`BookRevision`).
 
 ### Server-specified aliases
 
-Services **may** reserve specific IDs to be [aliases][alias] (e.g.
-`latest`). These are read-only and managed by the service.
+Services **may** reserve specific IDs to be [aliases][alias] (e.g. `latest`).
+These are read-only and managed by the service.
 
 ```
 GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
@@ -130,9 +134,10 @@ GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
 If specific IDs are reserved, services **must** document those IDs.
 
 - If a `latest` ID exists, it **must** represent the most recently created
-revision. The content of `publishers/{publisher}/books/{book}/revisions/latest`
-and `publishers/{publisher}/books/{book}` can differ, as the latest revision may
-be different from the current state of the resource.
+  revision. The content of
+  `publishers/{publisher}/books/{book}/revisions/latest` and
+  `publishers/{publisher}/books/{book}` can differ, as the latest revision may
+  be different from the current state of the resource.
 
 ### User-specified aliases
 
@@ -222,15 +227,16 @@ message AliasBookRevisionRequest {
 {% endtabs %}
 
 - The request message **must** have a `path` field:
-  - The field **must** be [annotated as required](/field-behavior-documentation).
+  - The field **must** be
+    [annotated as required](/field-behavior-documentation).
   - The field **must** identify the [resource type](/resource-types) that it
     references.
 - The request message **must** have a `alias` field:
   - The field **must** be [annotated as required][aip-203].
 - If the user calls the method with an existing `alias` with `overwrite` set to
-  true, the request **must** succeed and the alias will be updated to refer to the
-  provided revision. If `overwrite` is false, the request must fail with an error code
-  ALREADY_EXISTS (HTTP 409).
+  true, the request **must** succeed and the alias will be updated to refer to
+  the provided revision. If `overwrite` is false, the request must fail with an
+  error code ALREADY_EXISTS (HTTP 409).
 
 ### Rollback
 
@@ -317,21 +323,21 @@ message RollbackBookRequest {
 
 ### Child resources
 
-Resources with a revision history **may** have child resources. If they do, they
-**should** be a subset of the descendants of the original resource, and a given
-revision's descendants must be a subset of the descendants of the resource at
-the time the revision was created.
+Resources with a revision history **may** have child resources. If they do,
+they **should** be a subset of the descendants of the original resource, and a
+given revision's descendants must be a subset of the descendants of the
+resource at the time the revision was created.
 
 ### Standard methods
 
 Any standard methods **must** implement the corresponding AIPs (AIP-131,
 AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
 
-- List methods: By default, revisions in the list response **should** be ordered
-  in reverse chronological order. APIs **may** support the [`order_by`](./list#ordering) field to override the
-  default behavior.
-- If the revision supports aliasing, a delete method with the resource path
-  of the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
+- List methods: By default, revisions in the list response **should** be
+  ordered in reverse chronological order. APIs **may** support the
+  [`order_by`](./list#ordering) field to override the default behavior.
+- If the revision supports aliasing, a delete method with the resource path of
+  the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
   deleting the resource.
 
 As revisions are nested under the resource, also see [cascading delete][].
@@ -340,8 +346,8 @@ As revisions are nested under the resource, also see [cascading delete][].
 
 ### For the name "revision"
 
-There was significant debate about what to call this pattern, with the following
-as proposed options:
+There was significant debate about what to call this pattern, with the
+following as proposed options:
 
 - snapshots
 - revisions
@@ -354,9 +360,8 @@ Among those, revision was chosen because:
   conversations where it could mean one or the other.
 - The term "snapshot" is also used for snapshots of datastores, which may not
   follow this pattern.
-- The term "revision" does not have many conflicts with terms when describing an
-  API or resource.
-
+- The term "revision" does not have many conflicts with terms when describing
+  an API or resource.
 
 ## History
 
@@ -372,10 +377,10 @@ a resource, or its revision.
 
 It also had several disadvantages:
 
--  List revisions is a custom method (`:listRevisions`) on the resource.
--  Delete revision is a custom method on the resource.
--  Not visible in API discovery documenation.
--  Resource IDs cannot use the `@` symbol.
+- List revisions is a custom method (`:listRevisions`) on the resource.
+- Delete revision is a custom method on the resource.
+- Not visible in API discovery documenation.
+- Resource IDs cannot use the `@` symbol.
 
 The guidance was modified ultimately to enable revisions to behave like a
 resource, which reduces users' cognitive load and allows resource-oriented
@@ -387,4 +392,5 @@ clients to easily list, get, create, update, and delete revisions.
 
 [alias]: ./0122.md#resource-id-aliases
 [cascading delete]: ./0135.md#cascading-delete
-[UUID4]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
+[UUID4]:
+  https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)

--- a/aep/general/0191/aep.md.j2
+++ b/aep/general/0191/aep.md.j2
@@ -19,9 +19,9 @@ syntax = "proto3";
 package example.cloud.translation.v3;
 ```
 
-APIs **must** reside in a directory that matches the protocol buffer
-`package` directive. For example, the package above dictates that the directory
-be `example/cloud/translation/v3`.
+APIs **must** reside in a directory that matches the protocol buffer `package`
+directive. For example, the package above dictates that the directory be
+`example/cloud/translation/v3`.
 
 ## File names
 
@@ -29,8 +29,8 @@ It is often useful to divide API definitions into multiple files. File names
 **must** use `snake_case`.
 
 APIs **should** have an obvious "entry" file, generally named after the API
-itself. An API with a small number of discrete services **may** have a separate entry
-file per service.
+itself. An API with a small number of discrete services **may** have a separate
+entry file per service.
 
 APIs with only one file **should** use a filename corresponding to the name of
 the API.

--- a/aep/general/0192/aep.md.j2
+++ b/aep/general/0192/aep.md.j2
@@ -76,10 +76,10 @@ Comments **should** use `code font` for field or method names and for literals
 Raw HTML **must not** be used.
 
 "ASCII art" attempts to present a diagram within the protos **must not** be
-used. The Markdown within the protos is consumed by a large number of renderers,
-and any ASCII art is very unlikely to be well-presented by all of them. If
-a diagram is useful in order to understand the API, include a link to a
-documentation page containing the diagram as an image.
+used. The Markdown within the protos is consumed by a large number of
+renderers, and any ASCII art is very unlikely to be well-presented by all of
+them. If a diagram is useful in order to understand the API, include a link to
+a documentation page containing the diagram as an image.
 
 ### Cross-references
 
@@ -107,8 +107,9 @@ trademark owner's current branding.
 
 ### Deprecations
 
-To deprecate a component (service, method, message, field, enum, or enum value),
-the `deprecated` [option](https://developers.google.com/protocol-buffers/docs/proto#options)
+To deprecate a component (service, method, message, field, enum, or enum
+value), the `deprecated`
+[option](https://developers.google.com/protocol-buffers/docs/proto#options)
 **must** be set to `true`, and the first line of the respective comment
 **must** start with `"Deprecated: "` and provide alternative solutions for
 developers. If there is no alternative solution, a deprecation reason **must**

--- a/aep/general/0205/aep.md.j2
+++ b/aep/general/0205/aep.md.j2
@@ -11,8 +11,8 @@ authors and API reviewers will not agree on the best design, and the best way
 to find out is by having users try out the API.
 
 However, once the feedback has been collected and the API is going to be
-promoted to beta, usability concerns and style issues need to be addressed.
-In order to ensure that these issues are not forgotten, they **should** be
+promoted to beta, usability concerns and style issues need to be addressed. In
+order to ensure that these issues are not forgotten, they **should** be
 explicitly documented in the API.
 
 ## Guidance

--- a/aep/general/0211/aep.md.j2
+++ b/aep/general/0211/aep.md.j2
@@ -14,8 +14,8 @@ authorization.
 
 If a request can not pass the authorization check for any reason, the service
 **must** error with `403 Forbidden`, and the corresponding error message
-**must** look like: "Permission `{p}` denied on resource `{r}` (or it might
-not exist)." This avoids leaking resource existence.
+**must** look like: "Permission `{p}` denied on resource `{r}` (or it might not
+exist)." This avoids leaking resource existence.
 
 If it is not possible to determine authorization for a resource because the
 resource does not exist, the service **should** check authorization to read
@@ -30,8 +30,8 @@ resource if called, but a user only has permission to call one of them.
 
 In this situation, the service **must** only check for authorization applicable
 to the operation being called, rather than check for related authorization that
-would provide permission to reveal existence. Such algorithms are complicated to
-implement correctly and prone to accidental leaks.
+would provide permission to reveal existence. Such algorithms are complicated
+to implement correctly and prone to accidental leaks.
 
 For example, consider a scenario where:
 

--- a/aep/general/0214/aep.md.j2
+++ b/aep/general/0214/aep.md.j2
@@ -1,9 +1,9 @@
 # Resource expiration
 
 Customers often want to provide the time that a given resource or resource
-attribute is no longer useful or valid (e.g. a rotating security key). Currently
-we recommend that customers do this by specifying an exact "expiration time"
-into a `Timestamp expire_time` field; however, this adds
+attribute is no longer useful or valid (e.g. a rotating security key).
+Currently we recommend that customers do this by specifying an exact
+"expiration time" into a `Timestamp expire_time` field; however, this adds
 additional strain on the user when they want to specify a relative time offset
 until expiration rather than a specific time until expiration.
 
@@ -14,12 +14,12 @@ library.
 
 ## Guidance
 
-1.  APIs wishing to convey an expiration **must** rely on a
-    `Timestamp` field called `expire_time`.
+1.  APIs wishing to convey an expiration **must** rely on a `Timestamp` field
+    called `expire_time`.
 2.  APIs wishing to allow a relative expiration time must define a `oneof`
     called `expiration` (or `{something}_expiration`) containing both the
-    `expire_time` field and a separate `Duration`
-    field called `ttl`, the latter marked as input only.
+    `expire_time` field and a separate `Duration` field called `ttl`, the
+    latter marked as input only.
 3.  APIs **must** always return the expiration time in the `expire_time` field
     and leave the `ttl` field blank when retrieving the resource.
 4.  APIs that rely on the specific semantics of a "time to live" (e.g., DNS
@@ -30,6 +30,7 @@ library.
 ### Example
 
 {% tab proto %}
+
 ```proto
 message ExpiringResource {
   // google.api.resource and other annotations and fields
@@ -45,8 +46,8 @@ message ExpiringResource {
   }
 }
 ```
-{% tab oas %}
-**Note:**  OAS content not yet written.
+
+{% tab oas %} **Note:** OAS content not yet written.
 
 {% endtabs %}
 

--- a/aep/general/0216/aep.md.j2
+++ b/aep/general/0216/aep.md.j2
@@ -36,10 +36,10 @@ At a high level:
   temporary and will resolve to another state on its own, with no further user
   action.
 
-**Note:** Only add states that are useful to customers. Exposing a
-large number of states simply because they exist in your internal system is
-unnecessary and adds confusion for customers. Each state **must** come with a
-use case for why it is necessary.
+**Note:** Only add states that are useful to customers. Exposing a large number
+of states simply because they exist in your internal system is unnecessary and
+adds confusion for customers. Each state **must** come with a use case for why
+it is necessary.
 
 ### Output only
 


### PR DESCRIPTION
Some people are using a new version of prettier.
Using an old one can increase friction
for new contributors.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [ ] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [ ] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
