### PR TITLE
Replace Graphviz diagram with Mermaid

### DIFF
--- a/aep/general/0001/aep.md.j2
+++ b/aep/general/0001/aep.md.j2
@@ -140,36 +140,26 @@ an AEP from proposal to implementation to final acceptance.
 ### Overview
 
 ```mermaid
-flowchart LR
-    %% Node styles
-    classDef orange fill:#ffa500,stroke:#333,stroke-width:1px;
-    classDef blue fill:lightskyblue,stroke:#333,stroke-width:1px;
-    classDef green fill:palegreen,stroke:#333,stroke-width:1px;
-    classDef red fill:mistyrose,stroke:#333,stroke-width:1px;
-    classDef steel fill:lightsteelblue,stroke:#333,stroke-width:1px;
+graph LR
+  classDef orange fill:#FFA500,stroke:#000,stroke-width:1px;
+  classDef lightskyblue fill:#87CEFA,stroke:#000,stroke-width:1px;
+  classDef palegreen fill:#98FB98,stroke:#000,stroke-width:1px;
+  classDef mistyrose fill:#FFE4E1,stroke:#000,stroke-width:1px;
+  classDef lightsteelblue fill:#B0C4DE,stroke:#000,stroke-width:1px;
 
-    %% Nodes
-    github_pr["GitHub PR"]
-    reviewing["Reviewing"]
-    approved["Approved"]
-    final["Final"]
-    withdrawn["Withdrawn"]
-    replaced["Replaced"]
+  github_pr((GitHub PR)):::orange
+  reviewing[Reviewing]:::lightskyblue
+  approved[Approved]:::palegreen
+  final[Final]:::palegreen
+  withdrawn[Withdrawn]:::mistyrose
+  replaced[Replaced]:::lightsteelblue
 
-    %% Edges
-    github_pr --> reviewing
-    reviewing --> approved
-    reviewing -.-> withdrawn
-    approved --> final
-    approved -.-> replaced
-    final -.-> replaced
-
-    %% Assign classes for colors
-    class github_pr orange
-    class reviewing blue
-    class approved,final green
-    class withdrawn red
-    class replaced steel
+  github_pr --> reviewing
+  reviewing --> approved
+  reviewing -.-> withdrawn
+  approved --> final
+  approved -.-> replaced
+  final -.-> replaced
 ```
 
 ### Proposing an AEP

--- a/aep/general/0001/aep.md.j2
+++ b/aep/general/0001/aep.md.j2
@@ -140,21 +140,36 @@ an AEP from proposal to implementation to final acceptance.
 ### Overview
 
 ```mermaid
-graph LR
-    direction LR
-    style github_pr fill:#ffa500,stroke:#333,stroke-width:2px
-    style reviewing fill:#add8e6,stroke:#333,stroke-width:2px
-    style approved fill:#90ee90,stroke:#333,stroke-width:2px
-    style final fill:#90ee90,stroke:#333,stroke-width:2px
-    style withdrawn fill:#ffe4e1,stroke:#333,stroke-width:2px
-    style replaced fill:#b0c4de,stroke:#333,stroke-width:2px
-    github_pr(GitHub PR) --o--> reviewing(Reviewing)
-    reviewing --o--> approved(Approved)
-    reviewing --o-- withdrawn(Withdrawn)
-    approved --o--> final(Final)
-    approved --o--> replaced(Replaced)
-    final --o--> replaced(Replaced)
-}
+flowchart LR
+    %% Node styles
+    classDef orange fill:#ffa500,stroke:#333,stroke-width:1px;
+    classDef blue fill:lightskyblue,stroke:#333,stroke-width:1px;
+    classDef green fill:palegreen,stroke:#333,stroke-width:1px;
+    classDef red fill:mistyrose,stroke:#333,stroke-width:1px;
+    classDef steel fill:lightsteelblue,stroke:#333,stroke-width:1px;
+
+    %% Nodes
+    github_pr["GitHub PR"]
+    reviewing["Reviewing"]
+    approved["Approved"]
+    final["Final"]
+    withdrawn["Withdrawn"]
+    replaced["Replaced"]
+
+    %% Edges
+    github_pr --> reviewing
+    reviewing --> approved
+    reviewing -.-> withdrawn
+    approved --> final
+    approved -.-> replaced
+    final -.-> replaced
+
+    %% Assign classes for colors
+    class github_pr orange
+    class reviewing blue
+    class approved,final green
+    class withdrawn red
+    class replaced steel
 ```
 
 ### Proposing an AEP

--- a/aep/general/0001/aep.md.j2
+++ b/aep/general/0001/aep.md.j2
@@ -139,23 +139,21 @@ an AEP from proposal to implementation to final acceptance.
 
 ### Overview
 
-```graphviz
-digraph d_front_back {
-  rankdir=LR;
-  node [ style="filled,solid" shape=box fontname="Roboto" ];
-  github_pr [ shape="oval" label="GitHub PR" fillcolor="orange" ];
-  reviewing [ label="Reviewing" fillcolor="lightskyblue" ];
-  approved [ label="Approved" fillcolor="palegreen" ];
-  final [ label="Final" fillcolor="palegreen" ];
-  withdrawn [ label="Withdrawn" fillcolor="mistyrose" ];
-  replaced [ label="Replaced" fillcolor="lightsteelblue" ];
-
-  github_pr -> reviewing;
-  reviewing -> approved;
-  reviewing -> withdrawn [ style=dashed, color=mistyrose3 ];
-  approved -> final;
-  approved -> replaced [ style=dashed, color=lightsteelblue3 ];
-  final -> replaced [ style=dashed color=lightsteelblue3 ];
+```mermaid
+graph LR
+    direction LR
+    style github_pr fill:#ffa500,stroke:#333,stroke-width:2px
+    style reviewing fill:#add8e6,stroke:#333,stroke-width:2px
+    style approved fill:#90ee90,stroke:#333,stroke-width:2px
+    style final fill:#90ee90,stroke:#333,stroke-width:2px
+    style withdrawn fill:#ffe4e1,stroke:#333,stroke-width:2px
+    style replaced fill:#b0c4de,stroke:#333,stroke-width:2px
+    github_pr(GitHub PR) --o--> reviewing(Reviewing)
+    reviewing --o--> approved(Approved)
+    reviewing --o-- withdrawn(Withdrawn)
+    approved --o--> final(Final)
+    approved --o--> replaced(Replaced)
+    final --o--> replaced(Replaced)
 }
 ```
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

I'd like to remove the Graphviz dependency from our site generator, so we're only using one diagramming tool. 

This is what the final diagram will look like (ignore the dotted background, I'm taking this from an online visualization tool):

<img width="686" alt="Screenshot 2025-04-17 at 5 02 35 PM" src="https://github.com/user-attachments/assets/0cfa4f9e-b093-4622-ad8a-9ace6e35b07b" />


## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [ ] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [ ] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
