### PR TITLE
feat(156): add x-aep-resource and singleton annotation

### DIFF
--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -59,7 +59,8 @@ message Topic {
 {% tab oas %}
 
 For OpenAPI 3.0, Resources must be defined in `#components/schemas` and use the
-`x-aep-resource` extension:
+[`x-aep-resource`](https://aep.dev/json-schema/extensions/x-aep-resource.json)
+extension:
 
 ```json
 {

--- a/aep/general/0156/aep.md.j2
+++ b/aep/general/0156/aep.md.j2
@@ -55,6 +55,12 @@ components:
         # additional properties...
       required:
         - name
+      x-aep-resource:
+        singular: config
+        plural: configs
+        patterns: ['users/{user}/config']
+        parents: ['user']
+        singleton: true
   parameters:
     user:
       in: path
@@ -95,6 +101,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Config'
 ```
+
+- Singleton resources **must** be annotated with the
+  [`x-aep-resource`](https://aep.dev/json-schema/extensions/x-aep-resource.json)
+  extension, specifying the field `singleton` as true.
 
 {% endtabs %}
 


### PR DESCRIPTION
Now that a formal x-aep-resource extension was added, adding
references to said extension. 

In addition, the `singleton` field was added. Adding appropriate
guidance.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
