### PR TITLE
fix(example, oas): switch to yaml tab syntax

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,5 +10,9 @@ jobs:
     container: node:20
     steps:
       - uses: actions/checkout@v3
+      # this must be installed to use the prettier version
+      # from the package.json file.
+      - name: install prettier.
+        run: npm install .
       - name: verify with prettier.
         run: npx prettier --check .

--- a/aep/general/example.oas.yaml
+++ b/aep/general/example.oas.yaml
@@ -1,981 +1,626 @@
-{
-  'info':
-    {
-      'title': 'bookstore.example.com',
-      'description': 'An API for bookstore.example.com',
-      'version': 'version not set',
-      'contact': { 'name': 'API support', 'email': 'aepsupport@aep.dev' },
-    },
-  'openapi': '3.1.0',
-  'servers': [{ 'url': 'http://localhost:8081' }],
-  'paths':
-    {
-      '/isbns':
-        {
-          'get':
-            {
-              'description': 'List method for isbn',
-              'operationId': 'ListIsbn',
-              'parameters':
-                [
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'next_page_token': { 'type': 'string' },
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/isbn',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for isbn',
-              'operationId': 'CreateIsbn',
-              'parameters':
-                [
-                  {
-                    'name': 'id',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/isbn' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/isbn' } },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/isbns/{isbn}':
-        {
-          'get':
-            {
-              'description': 'Get method for isbn',
-              'operationId': 'GetIsbn',
-              'parameters':
-                [
-                  {
-                    'name': 'isbn',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/isbn' },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-      '/publishers':
-        {
-          'get':
-            {
-              'description': 'List method for publisher',
-              'operationId': 'ListPublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'skip',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'filter',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'next_page_token': { 'type': 'string' },
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/publisher',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for publisher',
-              'operationId': 'CreatePublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'id',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/publishers/{publisher}':
-        {
-          'get':
-            {
-              'description': 'Get method for publisher',
-              'operationId': 'GetPublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-            },
-          'patch':
-            {
-              'description': 'Update method for publisher',
-              'operationId': 'UpdatePublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/merge-patch+json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/merge-patch+json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-          'put':
-            {
-              'description': 'Apply method for publisher',
-              'operationId': 'ApplyPublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-          'delete':
-            {
-              'description': 'Delete method for publisher',
-              'operationId': 'DeletePublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'force',
-                    'in': 'query',
-                    'schema': { 'type': 'boolean' },
-                  },
-                ],
-              'responses':
-                {
-                  '204':
-                    {
-                      'description': 'Successful response',
-                      'content': { 'application/json': { 'schema': {} } },
-                    },
-                },
-            },
-        },
-      '/publishers/{publisher}/books':
-        {
-          'get':
-            {
-              'description': 'List method for book',
-              'operationId': 'ListBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'next_page_token': { 'type': 'string' },
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/book',
-                                            },
-                                        },
-                                      'unreachable':
-                                        {
-                                          'type': 'array',
-                                          'items': { 'type': 'string' },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for book',
-              'operationId': 'CreateBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'id',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}':
-        {
-          'get':
-            {
-              'description': 'Get method for book',
-              'operationId': 'GetBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-            },
-          'patch':
-            {
-              'description': 'Update method for book',
-              'operationId': 'UpdateBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/merge-patch+json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/merge-patch+json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                  'required': true,
-                },
-            },
-          'put':
-            {
-              'description': 'Apply method for book',
-              'operationId': 'ApplyBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                  'required': true,
-                },
-            },
-          'delete':
-            {
-              'description': 'Delete method for book',
-              'operationId': 'DeleteBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'force',
-                    'in': 'query',
-                    'schema': { 'type': 'boolean' },
-                  },
-                ],
-              'responses':
-                {
-                  '204':
-                    {
-                      'description': 'Successful response',
-                      'content': { 'application/json': { 'schema': {} } },
-                    },
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}/editions':
-        {
-          'get':
-            {
-              'description': 'List method for book-edition',
-              'operationId': 'ListBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'next_page_token': { 'type': 'string' },
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/book-edition',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for book-edition',
-              'operationId': 'CreateBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'id',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  '$ref': '#/components/schemas/book-edition',
-                                },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/book-edition' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}/editions/{book-edition}':
-        {
-          'get':
-            {
-              'description': 'Get method for book-edition',
-              'operationId': 'GetBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book-edition',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  '$ref': '#/components/schemas/book-edition',
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'delete':
-            {
-              'description': 'Delete method for book-edition',
-              'operationId': 'DeleteBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book-edition',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '204':
-                    {
-                      'description': 'Successful response',
-                      'content': { 'application/json': { 'schema': {} } },
-                    },
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}:archive':
-        {
-          'post':
-            {
-              'description': 'Custom method archive for book',
-              'operationId': ':ArchiveBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    { 'success': { 'type': 'boolean' } },
-                                  'x-aep-field-numbers': { '0': 'success' },
-                                },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    { 'application/json': { 'schema': { 'type': 'object' } } },
-                  'required': true,
-                },
-            },
-        },
-    },
-  'components':
-    {
-      'schemas':
-        {
-          'book':
-            {
-              'type': 'object',
-              'properties':
-                {
-                  'author':
-                    {
-                      'type': 'array',
-                      'items':
-                        {
-                          'type': 'object',
-                          'properties':
-                            {
-                              'firstName': { 'type': 'string' },
-                              'lastName': { 'type': 'string' },
-                            },
-                          'x-aep-field-numbers':
-                            { '1': 'firstName', '2': 'lastName' },
-                        },
-                    },
-                  'edition': { 'type': 'integer', 'format': 'int32' },
-                  'isbn': { 'type': 'array', 'items': { 'type': 'string' } },
-                  'path': { 'type': 'string', 'readOnly': true },
-                  'price': { 'type': 'number', 'format': 'float' },
-                  'published': { 'type': 'boolean' },
-                },
-              'x-aep-resource':
-                {
-                  'singular': 'book',
-                  'plural': 'books',
-                  'patterns': ['publishers/{publisher}/books/{book}'],
-                  'parents': ['publisher'],
-                },
-              'x-aep-field-numbers':
-                {
-                  '0': 'author',
-                  '1': 'isbn',
-                  '10018': 'path',
-                  '2': 'price',
-                  '3': 'published',
-                  '4': 'edition',
-                },
-              'required': ['isbn', 'price', 'published'],
-            },
-          'book-edition':
-            {
-              'type': 'object',
-              'properties':
-                {
-                  'displayname': { 'type': 'string' },
-                  'path': { 'type': 'string', 'readOnly': true },
-                },
-              'x-aep-resource':
-                {
-                  'singular': 'book-edition',
-                  'plural': 'book-editions',
-                  'patterns':
-                    [
-                      'publishers/{publisher}/books/{book}/editions/{book-edition}',
-                    ],
-                  'parents': ['book'],
-                },
-              'x-aep-field-numbers': { '1': 'displayname', '10018': 'path' },
-              'required': ['displayname'],
-            },
-          'isbn':
-            {
-              'type': 'object',
-              'properties': { 'path': { 'type': 'string', 'readOnly': true } },
-              'x-aep-resource':
-                {
-                  'singular': 'isbn',
-                  'plural': 'isbns',
-                  'patterns': ['isbns/{isbn}'],
-                },
-              'x-aep-field-numbers': { '10018': 'path' },
-            },
-          'publisher':
-            {
-              'type': 'object',
-              'properties':
-                {
-                  'description': { 'type': 'string' },
-                  'path': { 'type': 'string', 'readOnly': true },
-                },
-              'x-aep-resource':
-                {
-                  'singular': 'publisher',
-                  'plural': 'publishers',
-                  'patterns': ['publishers/{publisher}'],
-                },
-              'x-aep-field-numbers': { '1': 'description', '10018': 'path' },
-            },
-        },
-    },
-}
+info:
+  title: bookstore.example.com
+  description: An API for bookstore.example.com
+  version: version not set
+  contact:
+    name: API support
+    email: aepsupport@aep.dev
+openapi: 3.1.0
+servers:
+  - url: http://localhost:8081
+paths:
+  /isbns:
+    get:
+      description: List method for isbn
+      operationId: ListIsbn
+      parameters:
+        - name: max_page_size
+          in: query
+          schema:
+            type: integer
+        - name: page_token
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_token:
+                    type: string
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/isbn'
+    post:
+      description: Create method for isbn
+      operationId: CreateIsbn
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/isbn'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/isbn'
+        required: true
+  /isbns/{isbn}:
+    get:
+      description: Get method for isbn
+      operationId: GetIsbn
+      parameters:
+        - name: isbn
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/isbn'
+  /publishers:
+    get:
+      description: List method for publisher
+      operationId: ListPublisher
+      parameters:
+        - name: max_page_size
+          in: query
+          schema:
+            type: integer
+        - name: page_token
+          in: query
+          schema:
+            type: string
+        - name: skip
+          in: query
+          schema:
+            type: integer
+        - name: filter
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_token:
+                    type: string
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/publisher'
+    post:
+      description: Create method for publisher
+      operationId: CreatePublisher
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/publisher'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/publisher'
+        required: true
+  /publishers/{publisher}:
+    get:
+      description: Get method for publisher
+      operationId: GetPublisher
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/publisher'
+    patch:
+      description: Update method for publisher
+      operationId: UpdatePublisher
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/merge-patch+json:
+              schema:
+                $ref: '#/components/schemas/publisher'
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/publisher'
+        required: true
+    put:
+      description: Apply method for publisher
+      operationId: ApplyPublisher
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/publisher'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/publisher'
+        required: true
+    delete:
+      description: Delete method for publisher
+      operationId: DeletePublisher
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: force
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '204':
+          description: Successful response
+          content:
+            application/json:
+              schema: {}
+  /publishers/{publisher}/books:
+    get:
+      description: List method for book
+      operationId: ListBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: max_page_size
+          in: query
+          schema:
+            type: integer
+        - name: page_token
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_token:
+                    type: string
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/book'
+                  unreachable:
+                    type: array
+                    items:
+                      type: string
+    post:
+      description: Create method for book
+      operationId: CreateBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/book'
+        required: true
+  /publishers/{publisher}/books/{book}:
+    get:
+      description: Get method for book
+      operationId: GetBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book'
+    patch:
+      description: Update method for book
+      operationId: UpdateBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/merge-patch+json:
+              schema:
+                $ref: '#/components/schemas/book'
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/book'
+        required: true
+    put:
+      description: Apply method for book
+      operationId: ApplyBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/book'
+        required: true
+    delete:
+      description: Delete method for book
+      operationId: DeleteBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: force
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '204':
+          description: Successful response
+          content:
+            application/json:
+              schema: {}
+  /publishers/{publisher}/books/{book}/editions:
+    get:
+      description: List method for book-edition
+      operationId: ListBookEdition
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: max_page_size
+          in: query
+          schema:
+            type: integer
+        - name: page_token
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_token:
+                    type: string
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/book-edition'
+    post:
+      description: Create method for book-edition
+      operationId: CreateBookEdition
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book-edition'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/book-edition'
+        required: true
+  /publishers/{publisher}/books/{book}/editions/{book-edition}:
+    get:
+      description: Get method for book-edition
+      operationId: GetBookEdition
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book-edition
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book-edition'
+    delete:
+      description: Delete method for book-edition
+      operationId: DeleteBookEdition
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book-edition
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful response
+          content:
+            application/json:
+              schema: {}
+  /publishers/{publisher}/books/{book}:archive:
+    post:
+      description: Custom method archive for book
+      operationId: :ArchiveBook
+      parameters:
+        - name: publisher
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: book
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                x-aep-field-numbers:
+                  '0': success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        required: true
+components:
+  schemas:
+    book:
+      type: object
+      properties:
+        author:
+          type: array
+          items:
+            type: object
+            properties:
+              firstName:
+                type: string
+              lastName:
+                type: string
+            x-aep-field-numbers:
+              '1': firstName
+              '2': lastName
+        edition:
+          type: integer
+          format: int32
+        isbn:
+          type: array
+          items:
+            type: string
+        path:
+          type: string
+          readOnly: true
+        price:
+          type: number
+          format: float
+        published:
+          type: boolean
+      x-aep-resource:
+        singular: book
+        plural: books
+        patterns:
+          - publishers/{publisher}/books/{book}
+        parents:
+          - publisher
+      x-aep-field-numbers:
+        '0': author
+        '1': isbn
+        '10018': path
+        '2': price
+        '3': published
+        '4': edition
+      required:
+        - isbn
+        - price
+        - published
+    book-edition:
+      type: object
+      properties:
+        displayname:
+          type: string
+        path:
+          type: string
+          readOnly: true
+      x-aep-resource:
+        singular: book-edition
+        plural: book-editions
+        patterns:
+          - publishers/{publisher}/books/{book}/editions/{book-edition}
+        parents:
+          - book
+      x-aep-field-numbers:
+        '1': displayname
+        '10018': path
+      required:
+        - displayname
+    isbn:
+      type: object
+      properties:
+        path:
+          type: string
+          readOnly: true
+      x-aep-resource:
+        singular: isbn
+        plural: isbns
+        patterns:
+          - isbns/{isbn}
+      x-aep-field-numbers:
+        '10018': path
+    publisher:
+      type: object
+      properties:
+        description:
+          type: string
+        path:
+          type: string
+          readOnly: true
+      x-aep-resource:
+        singular: publisher
+        plural: publishers
+        patterns:
+          - publishers/{publisher}
+      x-aep-field-numbers:
+        '1': description
+        '10018': path


### PR DESCRIPTION
The json-like syntax of the example OAS yaml was making it seem like the content coudl be treated like json, when it could not.

Using the standard yaml indented syntax clarifies this.

fixes #303

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
