### PR TITLE
fix(132): should -> must on parent field

### DIFF
--- a/aep/general/0122/aep.md.j2
+++ b/aep/general/0122/aep.md.j2
@@ -100,7 +100,7 @@ In this situation, the _message_ is still called `UserEvent` or
 **Note:** APIs wishing to do this **must** follow this format consistently
 throughout the API, or else not at all.
 
-### Resource ID segments
+### Resource ID
 
 A resource ID segment identifies the resource within its parent collection. In
 the resource path `publishers/123/books/les-miserables`, `123` is the resource

--- a/aep/general/0132/aep.md.j2
+++ b/aep/general/0132/aep.md.j2
@@ -27,15 +27,15 @@ result **must** be a list of resources.
   name **should** be the plural form of the resource's message name.
 - The request message **must** match the RPC name, with a `-Request` suffix.
 - The response message **must** match the RPC name, with a `-Response` suffix.
-  - The response **should** usually include fully-populated resources unless
-    there is a reason to return a partial response (see AEP-157).
+  - The response **should** include fully-populated resources unless there is a
+    reason to return a partial response (see AEP-157).
 - The HTTP verb **must** be `GET`.
-- If the collection has a parent resource, The URI **should** contain a field
+- If the collection has a parent resource, The URI **must** contain a field
   corresponding to the collection parent's name.
-  - This field **should** be called `parent`.
-  - The URI **should** have a variable corresponding to this field.
-  - The `parent` field **should** be the only variable in the URI path. All
-    remaining parameters **should** map to URI query parameters.
+  - This field **must** be called `parent`.
+  - The URI **must** have a variable corresponding to this field.
+  - The `parent` field **must** be the only variable in the URI path. All
+    remaining parameters **must** map to URI query parameters.
 - There **must not** be a `body` key in the `google.api.http` annotation.
 - There **should** be exactly one `google.api.method_signature` annotation with
   a value of `"parent"` if a parent exists, and an empty string otherwise.

--- a/aep/general/0132/aep.md.j2
+++ b/aep/general/0132/aep.md.j2
@@ -78,6 +78,7 @@ collection's URI:
   - The field **must** be [annotated as required][aep-203].
   - The field **must** identify the [resource type][] of the resource being
     listed with a `google.api.resource_reference` annotation.
+  - The field **must** accept the parent [path, _not_ the id](./0122)
 - The `max_page_size` and `page_token` fields, which support pagination,
   **must** be specified on all list request messages. For more information, see
   AEP-158.


### PR DESCRIPTION
Some guidance includes "should" on parent fields. However, this is a requirement in order for AEP clients and users to understand the resource hierarchy.

This is an artifact of the adaptation of the AEP from aip.dev, and currently there is not justification for the *should*.

Addresses #314 
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
