### PR TITLE
fix(pattern, oas): removing usage _id suffix in path parameters

### DIFF
--- a/aep/general/0122/aep.md.j2
+++ b/aep/general/0122/aep.md.j2
@@ -248,7 +248,7 @@ referencing the parent's resource type ([AEP-4][aep-4]).
 // Request message for ListBooks.
 message ListBooksRequest {
 // The publisher to list books from.
-// Format: publishers/{publisher_id}
+// Format: publishers/{publisher}
 string parent = 1 [(google.api.resource_reference) = {
   type: "apis.example.com/library/Publisher"
 }];
@@ -266,8 +266,8 @@ instead:
 message ListBooksRequest {
 // The parent to list books from.
 // Format:
-//   - publishers/{publisher_id}
-//   - authors/{author_id}
+//   - publishers/{publisher}
+//   - authors/{author}
 string parent = 1 [
   (google.api.field_behavior) = REQUIRED,
   (google.api.resource_reference) = {
@@ -320,7 +320,7 @@ string shelf = 2 [(google.api.resource_reference) = {
 **Note:** When referring to other resources in this way, we use the resource
 path as the value, not just the ID component. Services **should** use the
 resource path to reference resources when possible. If using the ID component
-alone is strictly necessary, the field **should** use an `_id` suffix (e.g.
+alone is strictly necessary, the field **must** use an `_id` suffix (e.g.
 `shelf_id`).
 
 ## Further reading

--- a/aep/general/0132/aep.md.j2
+++ b/aep/general/0132/aep.md.j2
@@ -62,8 +62,7 @@ collection's URI:
 - The URI **should** contain a variable for each individual ID in the resource
   hierarchy.
   - The path parameter for all resource IDs **must** be in the form
-    `{resourceName}_id` (such as `book_id`), and path parameters representing
-    the ID of parent resources **must** end with `Id`.
+    `{resource-singular}` (such as `/publishers/{publisher}`).
 
 {% endtabs %}
 

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -128,7 +128,7 @@ Services **may** reserve specific IDs to be [aliases][alias] (e.g. `latest`).
 These are read-only and managed by the service.
 
 ```
-GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
+GET /v1/publishers/{publisher}/books/{book}/revisions/{revision}
 ```
 
 If specific IDs are reserved, services **must** document those IDs.
@@ -177,7 +177,7 @@ message AliasBookRevisionRequest {
 ```json
 {
   "paths": {
-    "/v1/publishers/{publisher_id}/books/{book}/revisions/{revision}:alias": {
+    "/v1/publishers/{publisher}/books/{book}/revisions/{revision}:alias": {
       "post": {
         "requestBody": {
           "content": {


### PR DESCRIPTION
Currently, the AEPs have some inconsistencies in the naming  of path parameters, where some examples do not include a `_id`, while the official guidance does.

It is easier to reconcile the two to just not include _id, because:

- the `pattern` field in `x-aep-resource` already uses the resource singular. This is   a holdover from aips, so would be a pretty big change for existing APIs.
- the pattern field should be consistent with path parameters, as the oas / proto
  extraction logic leverages this to extract plural / singular names.

Addresses, but does not fully fix, #314.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [ ] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [ ] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
