### PR TITLE
fix(203): change category from fields to protobuf

### DIFF
--- a/aep/general/0203/aep.yaml
+++ b/aep/general/0203/aep.yaml
@@ -4,4 +4,4 @@ state: approved
 slug: field-behavior-documentation
 created: 2024-04-17
 placement:
-  category: fields
+  category: protobuf


### PR DESCRIPTION
## Summary
- Change AEP 203's category from "fields" to "protobuf"

## Test plan
- [x] Verify the category change in aep.yaml
- [x] Confirm no other files need updating

🤖 Generated with [Claude Code](https://claude.ai/code)