### PR TITLE
reorder: move Delete before Apply in standard-methods

### DIFF
--- a/aep/general/0135/aep.yaml
+++ b/aep/general/0135/aep.yaml
@@ -5,4 +5,4 @@ slug: delete
 created: 2024-02-11
 placement:
   category: standard-methods
-  order: 60
+  order: 50

--- a/aep/general/0137/aep.yaml
+++ b/aep/general/0137/aep.yaml
@@ -5,4 +5,4 @@ slug: apply
 created: 2024-11-13
 placement:
   category: standard-methods
-  order: 50
+  order: 60


### PR DESCRIPTION
## Summary

Reorders the standard-methods AEPs to move Delete before Apply.

**Current order:**
Methods, Get, List, Create, Update, Apply, Delete, Custom Methods

**New order:**
Methods, Get, List, Create, Update, Delete, Apply, Custom Methods

## Changes
- Delete (AEP-135): order 60 → 50
- Apply (AEP-137): order 50 → 60

## Test plan
- [ ] Verify AEP ordering displays correctly in documentation
- [ ] Confirm no other references need updating

🤖 Generated with [Claude Code](https://claude.ai/code)