### PR TITLE
feat(136): switch mime_type -> content_type

### DIFF
--- a/aep/general/0136/library.oas.yaml
+++ b/aep/general/0136/library.oas.yaml
@@ -15,7 +15,7 @@ paths:
             schema:
               description: Request structure to archive a book.
               properties:
-                mime_type:
+                content_type:
                   type: string
                   description: |
                     The target format for the archived book.

--- a/aep/general/0136/library.proto
+++ b/aep/general/0136/library.proto
@@ -48,7 +48,7 @@ message ArchiveBookRequest {
 
   // The target format for the archived book.
   // Must be "application/pdf", "application/rtf", or "application/epub+zip"
-  string mime_type = 2;
+  string content_type = 2;
 }
 
 // Response message for archiving a book.

--- a/aep/general/0143/aep.md.j2
+++ b/aep/general/0143/aep.md.j2
@@ -65,8 +65,8 @@ message Book {
 
 ### Content types
 
-Fields representing a content or media type **must** use [IANA media types][].
-For legacy reasons, the field **should** be called `mime_type`.
+Fields representing a content or media type **must** use [IANA media types][]
+and **should** be called `content_type`.
 
 ### Countries and regions
 


### PR DESCRIPTION
The mime_type was used at Google due to legacy reasons, but aep.dev is not constrained by Google guidelines.

Switching to the more common content_type.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [ ] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [ ] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
