### PR TITLE
fix(122): always use full resource path for API references

### DIFF
--- a/aep/general/0122/aep.md.j2
+++ b/aep/general/0122/aep.md.j2
@@ -147,23 +147,16 @@ all data returned from the API **must** use the canonical resource path.
 
 ### Full resource paths
 
-In most cases, resource paths are used within a single API only, or else they
-are used in contexts where the owning API is clear (for example,
-`string pubsub_topic`).
-
-However, sometimes it is necessary for services to refer to resources in an
-arbitrary API. In this situation, the service **should** use the _full resource
-path_, a schemeless URI with the owning API's service endpoint, followed by the
-relative resource path:
+In most cases, resource paths are used within a single API only. However,
+sometimes it is necessary for services to refer to resources in an arbitrary
+API. In this situation, the service **must** use the _full resource path_, a
+schemeless URI with the owning API's service endpoint, followed by the relative
+resource path:
 
 ```
 //apis.example.com/library/publishers/123/books/les-miserables
 //apis.example.com/calendar/users/vhugo1802
 ```
-
-**Note:** The full resource path **should not** be used for cross-API
-references where the owning API is clear; it is only used if a field refers to
-resources in multiple APIs where ambiguity is possible.
 
 ### Resource URIs
 

--- a/aep/general/0122/aep.md.j2
+++ b/aep/general/0122/aep.md.j2
@@ -8,8 +8,15 @@ the canonical identifier for the resources.
 
 ## Guidance
 
-All resource paths defined by an API **must** be unique within that API. (See
-the section on [full resource paths](#full-resource-paths) below for more
+### Resource Path
+
+A resource path refers to the the identifier for a specific resource, unique
+within an API.
+
+- A resource path **must** be unique with an API, referring to a single
+  resource.
+
+See the section on [full resource paths](#full-resource-paths) below for more
 information on referring to resources across APIs.)
 
 Resource paths are formatted according to the [URI path schema][], but without
@@ -55,11 +62,26 @@ users/vhugo1802
 single API (or else in situations where the owning API is clear from the
 context), and are only required to be unique within that scope. For this
 reason, they are sometimes called _relative resource paths_ to distinguish them
-from _full resource paths_ (discussed below).
+from _full resource paths_ (discussed below). Any official documentation
+**should not** use the term _relative resource path_, and **should** use the
+term _resource path_ instead.
 
 [aep-210]: ./0210.md
 [uri path schema]: https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
 [singleton resources]: https://aep.dev/singletons
+
+### Full resource paths
+
+In most cases, resource paths are used within a single API only. However,
+sometimes it is necessary for services to refer to resources in an arbitrary
+API. In this situation, the service **must** use the _full resource path_, a
+schemeless URI with the owning API's service endpoint, followed by the relative
+resource path:
+
+```
+//apis.example.com/library/publishers/123/books/les-miserables
+//apis.example.com/calendar/users/vhugo1802
+```
 
 ### Collection identifiers
 
@@ -144,19 +166,6 @@ information for the authenticated user.
 
 APIs **may** provide programmatic aliases for common lookup patterns. However,
 all data returned from the API **must** use the canonical resource path.
-
-### Full resource paths
-
-In most cases, resource paths are used within a single API only. However,
-sometimes it is necessary for services to refer to resources in an arbitrary
-API. In this situation, the service **must** use the _full resource path_, a
-schemeless URI with the owning API's service endpoint, followed by the relative
-resource path:
-
-```
-//apis.example.com/library/publishers/123/books/les-miserables
-//apis.example.com/calendar/users/vhugo1802
-```
 
 ### Resource URIs
 
@@ -276,15 +285,20 @@ other use cases, use a synonymous term if possible.
 
 ### Fields representing another resource
 
-When referencing a resource path for a different resource, the field **should**
-be of type `string` for the resource path, and the field name **should** be
-equivalent to the corresponding message's name in snake case.
+When referencing a resource path for a different resource:
 
+- The field **must** be of type `string`.
+- The value of the field **must** be one of:
+  - the full resource path.
+  - the resource path, only if the referenced resource is also local to the API
+    of the current resource.
+- The field name **should** be equivalent to the corresponding message's name
+  in snake case.
 - Field names **may** include a leading adjective if appropriate (such as
   `string dusty_book`).
 - Field names **should not** use the `_path` suffix unless the field would be
   ambiguous without it (e.g., `crypto_key_path`)
-- Fields representing another resource **should** provide the
+- In protobuf, fields representing another resource **should** provide the
   `google.api.resource_reference` annotation with the resource type being
   referenced.
 
@@ -310,11 +324,10 @@ string shelf = 2 [(google.api.resource_reference) = {
 }
 ```
 
-**Note:** When referring to other resources in this way, we use the resource
-path as the value, not just the ID component. Services **should** use the
-resource path to reference resources when possible. If using the ID component
-alone is strictly necessary, the field **should** use an `_id` suffix (e.g.
-`shelf_id`).
+**Note:** When referring to other resources in this way, APIs **should** use
+the resource path to reference resources when possible. If using the ID
+component alone is strictly necessary, the field **should** use an `_id` suffix
+(e.g. `shelf_id`).
 
 ## Further reading
 

--- a/aep/general/0124/aep.md.j2
+++ b/aep/general/0124/aep.md.j2
@@ -10,6 +10,9 @@ a resource may have a many-to-many relationship with another resource type.
 A resource **must** have at most one canonical parent, and `List` requests
 **must not** require two distinct "parents".
 
+Also see
+[resource paths for guidance on fields representing another resource](/0122#fields-representing-another-resource).
+
 ### Multiple many-to-one associations
 
 If a resource has a many-to-one relationship with multiple resource types, it


### PR DESCRIPTION
The previous guidance was ambiguous about when to use a full resource name vs a relative one. 

This ambiguity makes it difficult for clients to read the location of  the remote resource, as well as the ablity to resolve it as necessary.

Some forms of REST APIs already put the full resource name directly in the  payload, so there is precedence for this approach.

Clarifying the guidance to ensure consistent behavior for APIs.

fixes #264 

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
