### PR TITLE
feat(134): remove section on expensive fields.

### DIFF
--- a/aep/general/0134/aep.md.j2
+++ b/aep/general/0134/aep.md.j2
@@ -255,23 +255,6 @@ server-computed value, and **must** fail with an `ABORTED` error otherwise. The
 `update_mask` field in the request does not affect the behavior of the `etag`
 field, as it is not a field _being_ updated.
 
-### Expensive fields
-
-APIs sometimes encounter situations where some fields on a resource are
-expensive or impossible to reliably return.
-
-This can happen in a few situations:
-
-- A resource may have some fields that are very expensive to compute, and that
-  are generally not useful to the customer on update requests.
-- A single resource sometimes represents an amalgamation of data from multiple
-  underlying (and eventually consistent) data sources. In these situations, it
-  may be infeasible to return authoritative information on the fields that were
-  not changed.
-
-In this situation, an API **may** return back only the fields that were updated
-and omit the rest. APIs that do this **must** document this behavior.
-
 ## Interface Definitions
 
 {% tab proto %}


### PR DESCRIPTION
This section overlaps with AEP-157. In addition,
adding specific guidance to a single AEP is inconsistent with the other standard methods.

fixes #127

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [ ] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [ ] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
