### PR TITLE
Change AEP-145 examples to Proto / OpenAPI

### DIFF
--- a/aep/general/0145/aep.md.j2
+++ b/aep/general/0145/aep.md.j2
@@ -10,18 +10,39 @@ subtle ways depending on the type of range being discussed.
 A resource or message representing a range **should** ordinarily use two
 separate fields of the same type, with prefixes `start_` and `end_`:
 
-```typescript
+{% tab proto %}
+```proto
 // A representation of a chapter in a book.
-interface Chapter {
-  title: string;
+message Chapter {
+  string title = 1;
 
   // The page where this chapter begins.
-  start_page: number;
+  int32 start_page = 2;
 
   // The page where the next chapter or section begins.
-  end_page: number;
+  int32 end_page = 3;
 }
 ```
+{% endtab %}
+
+{% tab oas %}
+```yaml
+# A representation of a chapter in a book.
+Chapter:
+  type: object
+  properties:
+    title:
+      type: string
+    start_page:
+      type: integer
+      format: int32
+      description: The page where this chapter begins.
+    end_page:
+      type: integer
+      format: int32
+      description: The page where the next chapter or section begins.
+```
+{% endtab %}
 
 ### Inclusive or exclusive ranges
 
@@ -53,18 +74,39 @@ closed, on Fridays.
 
 In this situation, the prefixes `first` and `last` **should** be used instead:
 
-```typescript
+{% tab proto %}
+```proto
 // A representation of a chapter in a book.
-interface Chapter {
-  title: string;
+message Chapter {
+  string title = 1;
 
   // The first page of the chapter.
-  first_page: number;
+  int32 first_page = 2;
 
   // The last page of the chapter.
-  last_page: number;
+  int32 last_page = 3;
 }
 ```
+{% endtab %}
+
+{% tab oas %}
+```yaml
+# A representation of a chapter in a book.
+Chapter:
+  type: object
+  properties:
+    title:
+      type: string
+    first_page:
+      type: integer
+      format: int32
+      description: The first page of the chapter.
+    last_page:
+      type: integer
+      format: int32
+      description: The last page of the chapter.
+```
+{% endtab %}
 
 Fields representing ranges with significant colloquial precedent for inclusive
 start and end values **should** use inclusive end values with `first_` and

--- a/aep/general/0145/aep.md.j2
+++ b/aep/general/0145/aep.md.j2
@@ -91,8 +91,6 @@ message Chapter {
 }
 ```
 
-{% endtab %}
-
 {% tab oas %}
 
 ```yaml
@@ -112,7 +110,7 @@ Chapter:
       description: The last page of the chapter.
 ```
 
-{% endtab %}
+{% endtabs %}
 
 Fields representing ranges with significant colloquial precedent for inclusive
 start and end values **should** use inclusive end values with `first_` and

--- a/aep/general/0145/aep.md.j2
+++ b/aep/general/0145/aep.md.j2
@@ -44,7 +44,7 @@ Chapter:
       description: The page where the next chapter or section begins.
 ```
 
-{% endtab %}
+{% endtabs %}
 
 ### Inclusive or exclusive ranges
 

--- a/aep/general/0145/aep.md.j2
+++ b/aep/general/0145/aep.md.j2
@@ -11,6 +11,7 @@ A resource or message representing a range **should** ordinarily use two
 separate fields of the same type, with prefixes `start_` and `end_`:
 
 {% tab proto %}
+
 ```proto
 // A representation of a chapter in a book.
 message Chapter {
@@ -23,9 +24,9 @@ message Chapter {
   int32 end_page = 3;
 }
 ```
-{% endtab %}
 
 {% tab oas %}
+
 ```yaml
 # A representation of a chapter in a book.
 Chapter:
@@ -42,6 +43,7 @@ Chapter:
       format: int32
       description: The page where the next chapter or section begins.
 ```
+
 {% endtab %}
 
 ### Inclusive or exclusive ranges
@@ -75,6 +77,7 @@ closed, on Fridays.
 In this situation, the prefixes `first` and `last` **should** be used instead:
 
 {% tab proto %}
+
 ```proto
 // A representation of a chapter in a book.
 message Chapter {
@@ -87,9 +90,11 @@ message Chapter {
   int32 last_page = 3;
 }
 ```
+
 {% endtab %}
 
 {% tab oas %}
+
 ```yaml
 # A representation of a chapter in a book.
 Chapter:
@@ -106,6 +111,7 @@ Chapter:
       format: int32
       description: The last page of the chapter.
 ```
+
 {% endtab %}
 
 Fields representing ranges with significant colloquial precedent for inclusive


### PR DESCRIPTION
Closes #310 

This replaces the Typescript syntax with Proto / OpenAPI.