### PR TITLE
feat(102): add new AEP around APIs

### DIFF
--- a/aep/general/0003/aep.md.j2
+++ b/aep/general/0003/aep.md.j2
@@ -63,7 +63,7 @@ Buffers by an `rpc` definition, or in HTTP via a `method` and a `path`.
 
 The name by which to refer to an API.
 
-See [API Name](./0004#api-name)
+See [API Name](/apis#api-name)
 
 ### API Request
 

--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -14,27 +14,8 @@ tools such as Kubernetes or GraphQL interact with APIs from multiple providers.
 ## Guidance
 
 APIs **must** define a resource type for each resource in the API, according to
-the following pattern: `{API Name}/{Type Name}`. The type name:
-
-### API Name
-
-An API name is a string that **must** uniquely identify the API.
-
-In practice, it is difficult to prevent the re-use of the name across different
-APIs. Therefore the API should use something, such as the domain name of the
-primary server hosting the API, as the name.
-
-If a primary server does not exist (for example, a public cloud where every
-domain always includes a regional subdomain), then a similar placeholder that
-can still ensure uniqueness can be used. For example APIs served at
-`{region}.cloud-storage.public-cloud.com` may use
-`cloud-storage.public-cloud.com`.
-
-The API Name:
-
-- **must** only uses valid domain name characters (`[.-a-z0-9]`), as specified
-  in [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1).
-- **must** use all lower case.
+the following pattern: `{API Name}/{Type Name}`. Also see
+[API Name](/apis#api-name).
 
 ### Type name
 
@@ -45,7 +26,7 @@ The type name:
 
 - **must** Only contain ASCII alphanumeric characters.
 - **must** Start with a lowercase letter.
-- **must** Be of the singular form of the noun.
+- **must** Be of the singular form of the resource.
 - **must** Use kebab case.
 
 ### Examples
@@ -96,6 +77,7 @@ extension:
       "UserEvent": {
         "type": "object",
         "x-aep-resource": {
+          "type": "user.example.com/user-event",
           "singular": "user-event",
           "plural": "user-events",
           "patterns": [
@@ -112,6 +94,7 @@ extension:
 
 {% endtabs %}
 
+- The `type` field **must** be the resource type `{API Name}/{Type Name}`
 - The `singular` field **must** be the kebab-case singular type name.
 - The `plural` field **must** be the kebab-case plural of the singular.
 

--- a/aep/general/0102/aep.md.j2
+++ b/aep/general/0102/aep.md.j2
@@ -1,0 +1,56 @@
+# APIs and API terminology
+
+This AEP describes the terms used to describe various parts of an API
+specification in depth.
+
+## Guidance
+
+### API Name
+
+An API name is a string that **must** uniquely identify the API. It serves as a
+namespace where elements of an API are defined, including:
+
+- [resource types][/resource-types]
+- [methods][/standard-methods]
+
+In practice, it is difficult to prevent the re-use of the name across different
+APIs. Therefore the API should use something, such as the domain name of the
+primary server hosting the API and a possible path prefix, as the name.
+
+If a primary server does not exist (for example, a public cloud where every
+domain always includes a regional subdomain), then a similar placeholder that
+can still ensure uniqueness can be used. For example APIs served at
+`{region}.cloud-storage.public-cloud.com` may use
+`cloud-storage.public-cloud.com`.
+
+The API Name:
+
+- **must** only uses valid domain name characters as specified in
+  [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1), or a
+  backslash `[.-a-z0-9/]`)
+- **must** use all lower case.
+- **should not** use path prefixes that could also be misconstrued as a
+  resource collection (e.g. `apis.examples.com/users`)
+
+### API Name Examples
+
+- `networking.istio.io`
+- `pubsub.example.com`
+- `spanner.example.com/v1`
+- `apis.example.com/user` (valid, but discouraged to possible confusion with a
+  collection name.).
+
+## API Services
+
+An API service is distinct from an API name: A name is a common string that is
+used to define an API agnostic of the address by which it is served, while an
+API service is a live service which exposes an API.
+
+In many cases, the address of an API service and an API name may be identical
+(for example, an api `api.example.com` may expose that same API at
+`api.example.com`).
+
+An API name **must not** be assumed to be an address of an API. Instead, use a
+location where that metadata is stored. For example, OpenAPI provides a
+[server object](https://spec.openapis.org/oas/v3.1.1.html#server-object) for
+this purpose.

--- a/aep/general/0102/aep.md.j2
+++ b/aep/general/0102/aep.md.j2
@@ -44,7 +44,10 @@ The API Name:
 
 An API service is distinct from an API name: A name is a common string that is
 used to define an API agnostic of the address by which it is served, while an
-API service is a live service which exposes an API.
+API service is a live service which exposes an API. For example, a staging and
+production environment (`staging.service.com`), or different regions
+(`us-west.service.com`) may have different API services, but will share the
+same API.
 
 In many cases, the address of an API service and an API name may be identical
 (for example, an api `api.example.com` may expose that same API at

--- a/aep/general/0102/aep.yaml
+++ b/aep/general/0102/aep.yaml
@@ -1,0 +1,7 @@
+---
+id: 102
+state: approved
+slug: apis
+created: 2025-09-27
+placement:
+  category: general


### PR DESCRIPTION
Adding an AEP around APIs specifically, to include more specific guidance and a landing page for APIs.

Clarifying some guidance around the usage of sub-paths for API names: previously this was confusing as an example existed (`api.example.com/users`) which seemed to allow this, but the API name guidance did not allow path elements in the API  name.

Also adding guidance for the `type` field in the `x-aep-resource` oas annotation: this was missing from the schema annotation previously, which effectively did not require placing the  api name anywhere in an OAS schema description.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [x] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
