### PR TITLE
feat(154): clarify behavior if not supported

### DIFF
--- a/aep/general/0154/aep.md.j2
+++ b/aep/general/0154/aep.md.j2
@@ -1,19 +1,22 @@
 # Preconditions
 
-APIs often need to validate that a client and server agree on the current state
-of a resource before taking some kind of action on that resource. For example,
-two processes updating the same resource in parallel could create a race
+Preconditions refers to the concept of a set of conditions that must be met
+before a particular operation (generally update of a resource) is performed.
+
+For example, APIs often need to validate that a client and server agree on the
+current state of a resource before taking some kind of action on that resource.
+e.g. two processes updating the same resource in parallel could create a race
 condition, where the latter process "stomps over" the effort of the former one.
 
-ETags provide a way to deal with this, by allowing the server to send a
-checksum based on the current content of a resource; when the client sends that
-checksum back, the server can ensure that the checksums match before acting on
-the request.
+`ETags`, `If-Match`, and `If-None-Match` provide a way to deal with this, by
+allowing the server to send a checksum based on the current content of a
+resource; when the client sends that checksum back, the server can ensure that
+the checksums match before acting on the request.
 
 ## Guidance
 
-When adding precondition checking to an API, the headers and behaviors **must**
-match
+When adding precondition checking to an API (`ETag`, `If-Match`, and
+`If-None-Match` headers), the behavior **must** match
 [preconditions](https://www.rfc-editor.org/rfc/rfc9110.html#name-preconditions)
 as documented in [RFC 9110][].
 

--- a/aep/general/0154/aep.md.j2
+++ b/aep/general/0154/aep.md.j2
@@ -1,4 +1,4 @@
-# Resource freshness validation
+# Preconditions
 
 APIs often need to validate that a client and server agree on the current state
 of a resource before taking some kind of action on that resource. For example,
@@ -11,6 +11,17 @@ checksum back, the server can ensure that the checksums match before acting on
 the request.
 
 ## Guidance
+
+When adding precondition checking to an API, the headers and behaviors **must**
+match
+[preconditions](https://www.rfc-editor.org/rfc/rfc9110.html#name-preconditions)
+as documented in [RFC 9110][].
+
+If a server recieves a conditional header it does not support, the service
+**should** return an `INAVLID_ARGUMENT / 400` response. A server **should**
+support all preconditions, or none of the them.
+
+### Etags
 
 A resource **may** provide an `ETag` header when retrieving a single resource
 when it is important to ensure that the client has an up to date resource
@@ -32,13 +43,6 @@ example, a valid ETag is `"foo"`, not `foo`.
 
 ETags **must** be based on an opaque checksum or hash of the resource that
 guarantees it will change if the resource changes.
-
-### Condition headers
-
-When adding precondition checking to an API, the headers and behaviors **must**
-match
-[preconditions](https://www.rfc-editor.org/rfc/rfc9110.html#name-preconditions)
-as documented in [RFC 9110][].
 
 ### If-Match / If-None-Match
 
@@ -68,9 +72,6 @@ If any conditional headers are supported for any operation within a service,
 the same conditional headers **must** be supported for all mutation methods
 (`POST`, `PATCH`, `PUT`, and `DELETE`) of any path that supports them, and
 **should** be supported uniformly for all operations across the service.
-
-If a server recieves a conditional header it does not support, the service
-**should** return an `INAVLID_ARGUMENT / 400` response.
 
 If any validator or conditional headers are supported for any operations in the
 service, the use of unsupported conditional headers **must** result in a

--- a/aep/general/0154/aep.md.j2
+++ b/aep/general/0154/aep.md.j2
@@ -20,7 +20,7 @@ When adding precondition checking to an API (`ETag`, `If-Match`, and
 [preconditions](https://www.rfc-editor.org/rfc/rfc9110.html#name-preconditions)
 as documented in [RFC 9110][].
 
-If a server recieves a conditional header it does not support, the service
+If a server receives a conditional header it does not support, the service
 **should** return an `INAVLID_ARGUMENT / 400` response. A server **should**
 support all preconditions, or none of the them.
 

--- a/aep/general/0154/aep.yaml
+++ b/aep/general/0154/aep.yaml
@@ -1,8 +1,10 @@
 ---
 id: 154
 state: approved
-slug: etags
+slug: preconditions
 created: 2019-07-24
 placement:
   category: design-patterns
   order: 30
+redirect_from:
+  - /etags


### PR DESCRIPTION
There was ambiguity around what to do if preconditions are not  supported by an API. This guidance already existed in some  form in the AEP, but raising it up front and center to help clarify universally what the behavior should be.

In addition, renaming the aep from `/etags` and "resource freshness validation" to "preconditions", to match the IETF RFC.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [ ] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [ ] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [ ] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [ ] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
