### PR TITLE
feat(134): replace etag guidance with 154 reference

### DIFF
--- a/aep/general/0134/aep.md.j2
+++ b/aep/general/0134/aep.md.j2
@@ -206,54 +206,11 @@ Therefore, given the ability of these two different patch mechanisms to
 interoperate while maintaining idiomatic practices, this divergence was
 concluded to be the least worst option.
 
-### Etags
+### Etags and preconditions
 
-An API may sometimes need to allow users to send update requests which are
-guaranteed to be made against the most current data (a common use case for this
-is to detect and avoid race conditions). Resources which need to enable this do
-so by including a `string etag` field, which contains an opaque,
-server-computed value representing the content of the resource.
-
-In this situation, the resource **should** contain a `string etag` field:
-
-{% tab proto %}
-
-```proto
-message Book {
-  option (google.api.resource) = {
-    type: "library.example.com/Book"
-    pattern: "publishers/{publisher_id}/books/{book_id}"
-  };
-
-  // The resource path of the book.
-  // Format: publishers/{publisher_id}/books/{book_id}
-  string path = 1 [(google.api.field_behavior) = IDENTIFIER];
-
-  // The title of the book.
-  // Example: "Mary Poppins"
-  string title = 2;
-
-  // The author of the book.
-  // Example: "P.L. Travers"
-  string author = 3;
-
-  // The etag for this book.
-  // If this is provided on update, it must match the server's etag.
-  string etag = 4;
-}
-```
-
-{% tab oas %}
-
-{% sample '../example.oas.yaml', '$.components.schemas.publisher' %}
-
-{% endtabs %}
-
-The `etag` field **may** be either [required][] or [optional][]. If it is set,
-then the request **must** succeed if and only if the provided etag matches the
-server-computed value, and **must** fail with an `ABORTED` error otherwise. The
-`update_mask` field in the request does not affect the behavior of the `etag`
-field, as it is not a field _being_ updated.
+See [etags](/etags) for more information about adding headers and metadata such
+as `ETag` and `If-Match` for supporting resource freshness validation and other
+preconditions.
 
 ## Interface Definitions
 


### PR DESCRIPTION
Previously, there was bespoke guidance in the Update AEP that refered to using a custom ETag field in the resource for validating previous resource state.

This guidance somewhat duplicates the guidance in RFC 9110  and AEP-154 which states that it should be adhered to. This  duplication can lead to partial support of both, which in turn will make client integration more difficult.

Therefore, removing this guidance. Fixes #241

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [x] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
