### PR TITLE
fix(137): clarify behavior (field presence and errors).

### DIFF
--- a/aep/general/0137/aep.md.j2
+++ b/aep/general/0137/aep.md.j2
@@ -18,6 +18,11 @@ valuable for users to do so. Clients should also consider using
 [update](/update) methods instead to ensure forwards compatible requests (see
 [PATCH and PUT](#patch-and-put)).
 
+### Behavior
+
+- If a field in the request is not present, the service **must** not modify
+  this field.
+
 ### Operation
 
 Apply methods are specified using the following pattern:
@@ -107,14 +112,24 @@ Apply methods implement a common request message pattern:
 
 ### Errors
 
-See [errors](/errors), in particular
+If an resource does not have a field set which is labeled with required (either
+the protobuf [field behavior](/0203#required) or present in the JsonSchema
+`required` field), the request **must** fail with
+``INVALID_ARGUMENT / 400 Bad Request`.
+
+For additional guidance, see [errors](/errors), in particular
 [when to use PERMISSION_DENIED and NOT_FOUND errors](/errors#permission-denied).
 
 ### PATCH and PUT
 
-Note that `PUT` requests with fields missing in the resource may result in
-overwriting values in the resource with existing values. For that reason,
-AEP-compliant APIs generally use the `PATCH` HTTP verb.
+`PUT` requests with fields missing in the resource may result in overwriting
+values in the resource with existing values. Specifically in protobuf, the
+fields that do not have the `optional` annotation will use their default zero
+value, overwriting any previous value. This gap does not exist in an
+[update](/0134), where the `field_mask` field helps clarify which fields to
+overwrite.
+
+As such AEP-compliant clients **should** use the `PATCH` HTTP verb.
 
 See [AEP-134's patch and put](/134#patch-and-put) for more information.
 


### PR DESCRIPTION
Filling some gaps in the guidance to clarify what to do if  fields are not present. As well as if fields are not  present.

Fixes #123.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [x] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
